### PR TITLE
Modify a result message on `/generate crud` to tell the tableName.

### DIFF
--- a/kotowari-scaffold/src/main/java/kotowari/scaffold/command/ScaffoldCommandRegister.java
+++ b/kotowari-scaffold/src/main/java/kotowari/scaffold/command/ScaffoldCommandRegister.java
@@ -268,7 +268,7 @@ public class ScaffoldCommandRegister implements SystemCommandRegister {
                                     .addTaskListener(new LoggingTaskListener(transport))
                                     .invoke();
                         });
-                        transport.sendOut("Generated CRUD " + args[0]);
+                        transport.sendOut("Generated CRUD " + args[1]);
                     } else {
                         transport.sendOut("Usage: generate crud [tableName]");
                     }


### PR DESCRIPTION

Modify the message from
`Generated CRUD crud` to
`Generated CRUD PRODUCT` by  `enkan> /generate crud PRODUCT`
