### PR TITLE
Fix the incompatibility between Java8 and Java9

### DIFF
--- a/enkan-core/src/main/java/enkan/util/MixinUtils.java
+++ b/enkan-core/src/main/java/enkan/util/MixinUtils.java
@@ -30,7 +30,7 @@ public class MixinUtils {
                 modifiersField.setAccessible(true);
                 modifiersField.setInt(f, modifiers & ~Modifier.FINAL);
                 f.setAccessible(true);
-                f.set(lookup, MethodHandles.Lookup.PRIVATE);
+                f.set(lookup, MethodHandles.Lookup.PUBLIC | MethodHandles.Lookup.PRIVATE);
             }
             return lookup.unreflectSpecial(method, declaringClass);
         });


### PR DESCRIPTION
## enkan-system/src/main/java/enkan/config/ConfigurationLoader.java

Fix for project jigsaw ClassLoader change

http://qiita.com/kawasima/items/a29ae29b31d44abb14d0#appclassloader%E3%81%8Curlclassloader%E3%82%92%E7%B6%99%E6%89%BF%E3%81%97%E3%81%AA%E3%81%8F%E3%81%AA%E3%81%A3%E3%81%9F

## enkan-core/src/main/java/enkan/util/MixinUtils.java

Specification of MethodHandles.Lookup.in has been changed

- http://download.java.net/java/jdk9/docs/api/java/lang/invoke/MethodHandles.Lookup.html#in-java.lang.Class-
- https://docs.oracle.com/javase/8/docs/api/java/lang/invoke/MethodHandles.Lookup.html#in-java.lang.Class-
