### PR TITLE
Ignore case of cors request method

### DIFF
--- a/enkan-web/src/main/java/enkan/middleware/CorsMiddleware.java
+++ b/enkan-web/src/main/java/enkan/middleware/CorsMiddleware.java
@@ -41,7 +41,7 @@ public class CorsMiddleware extends AbstractWebMiddleware {
     @Override
     public HttpResponse handle(HttpRequest request, MiddlewareChain chain) {
         if (isCORSRequest(request)) {
-            if (!isOriginAllowed(request) || !methods.contains(request.getRequestMethod())) {
+            if (!isOriginAllowed(request) || !methods.stream().anyMatch(x -> x.equalsIgnoreCase(request.getRequestMethod()))) {
                 return invalidCors(request);
             }
             if (isPreflightRequest(request)) {
@@ -96,7 +96,7 @@ public class CorsMiddleware extends AbstractWebMiddleware {
     }
 
     private boolean isPreflightRequest(HttpRequest httpRequest) {
-        return Objects.equals(httpRequest.getRequestMethod(), "OPTIONS")
+        return Objects.equals(httpRequest.getRequestMethod().toUpperCase(), "OPTIONS")
                 && httpRequest.getHeaders().containsKey("Access-Control-Request-Method");
     }
 

--- a/enkan-web/src/main/java/enkan/middleware/CorsMiddleware.java
+++ b/enkan-web/src/main/java/enkan/middleware/CorsMiddleware.java
@@ -59,7 +59,7 @@ public class CorsMiddleware extends AbstractWebMiddleware {
                     responseHeaders.put("Access-Control-Allow-Credentials", "true");
                 }
                 if (maxage > 0L) {
-                    responseHeaders.put("Access-Control-Max-Age", maxage);
+                    responseHeaders.put("Access-Control-Max-Age", String.valueOf(maxage));
                 }
                 return builder(HttpResponse.of(""))
                         .set(HttpResponse::setStatus, 200)

--- a/enkan-web/src/test/java/enkan/middleware/CorsMiddlewareTest.java
+++ b/enkan-web/src/test/java/enkan/middleware/CorsMiddlewareTest.java
@@ -102,7 +102,7 @@ public class CorsMiddlewareTest {
         HttpRequest request = builder(new DefaultHttpRequest()).build();
         request.setRequestMethod("options");
         request.setHeaders(Headers.of("Origin", "http://sample.com",
-                "Access-Control-Request-Method", "post"));
+                "Access-Control-Request-Method", "POST"));
 
         MiddlewareChain<HttpRequest, HttpResponse> chain = new DefaultMiddlewareChain<>(
                 new AnyPredicate<>(), null, (Endpoint<HttpRequest, HttpResponse>) req ->
@@ -119,6 +119,31 @@ public class CorsMiddlewareTest {
         assertThat(headers.get("Access-Control-Allow-Methods"), containsString("OPTIONS"));
         assertThat(headers.get("Access-Control-Allow-Headers"), containsString("Content-Type"));
         assertThat(headers.get("Access-Control-Allow-Credentials"), is("true"));
+    }
+
+    @Test
+    public void testCORSRequestWithLowerCaseMethod() throws Exception {
+        // SetUp
+        HttpRequest request = builder(new DefaultHttpRequest())
+                .set(HttpRequest::setHeaders, Headers.of("Origin", "http://sample.com"))
+                .set(HttpRequest::setRequestMethod, "post")
+                .build();
+
+        MiddlewareChain<HttpRequest, HttpResponse> chain = new DefaultMiddlewareChain<>(
+                new AnyPredicate<>(), null, (Endpoint<HttpRequest, HttpResponse>) req ->
+                builder(HttpResponse.of("hello"))
+                        .set(HttpResponse::setHeaders, Headers.of("Content-Type", "text/html")).build());
+
+        // Exercise
+        CorsMiddleware sut = new CorsMiddleware();
+        HttpResponse result = sut.handle(request, chain);
+
+        // Verify
+        Headers headers = result.getHeaders();
+        assertThat(result.getStatus(), is(200));
+        assertThat(headers.get("Access-Control-Allow-Origin"), is("*"));
+        assertThat(result.getBody(), is("hello"));
+        assertThat(headers.get("Content-Type"), is("text/html"));
     }
 
 }


### PR DESCRIPTION
The request method of the CORS request from chrome is lower case. (Maybe this depends on browser)
So it's necessary to use "equalsIgnoreCase" to check the request method of the CORS request.