### PR TITLE
perf: Cache injector mapping per controller method

### DIFF
--- a/kotowari/src/main/java/kotowari/middleware/ControllerInvokerMiddleware.java
+++ b/kotowari/src/main/java/kotowari/middleware/ControllerInvokerMiddleware.java
@@ -49,6 +49,15 @@ public class ControllerInvokerMiddleware<RES> implements Middleware<HttpRequest,
         }
     }
 
+    /**
+     * Resolve injectors for each parameter of the given method by type only.
+     *
+     * <p>All built-in {@link ParameterInjector#isApplicable} implementations
+     * determine applicability solely from the parameter type, so passing
+     * {@code null} for the request is safe.  Custom injectors that rely on
+     * request state at applicability-check time are not supported by this
+     * caching strategy and must be handled separately.
+     */
     private ParameterInjector<?>[] resolveInjectors(Method method) {
         Parameter[] parameters = method.getParameters();
         ParameterInjector<?>[] injectors = new ParameterInjector<?>[parameters.length];


### PR DESCRIPTION
## Summary

- Cache `ParameterInjector[]` per `Method` using `ConcurrentHashMap.computeIfAbsent()` to eliminate per-request stream scanning in `ControllerInvokerMiddleware.createArguments()`
- Also fixes `findAny()` → `findFirst()` to guarantee injector selection respects registration order (IMP-017)

## Changes

- Added `injectorCache` field and `resolveInjectors(Method)` method that pre-resolves injectors by parameter type on first invocation
- `createArguments()` now uses cached array with simple index loop instead of stream pipeline per request

## Resolves

- IMP-024: Cacheable injector mapping per method
- IMP-017: findAny → findFirst in ControllerInvokerMiddleware

## Test plan

- [x] All 32 kotowari tests pass
- [ ] Verify controller invocation works correctly in kotowari-example

🤖 Generated with [Claude Code](https://claude.com/claude-code)