### PR TITLE
fix: Wrap appendReplacement with Matcher.quoteReplacement in CodecUtils

### DIFF
--- a/enkan-web/src/main/java/enkan/util/CodecUtils.java
+++ b/enkan-web/src/main/java/enkan/util/CodecUtils.java
@@ -65,7 +65,7 @@ public class CodecUtils {
                     }
                     encodedSb.append(Integer.toString(d, 16));
                 }
-                m.appendReplacement(sb, encodedSb.toString());
+                m.appendReplacement(sb, Matcher.quoteReplacement(encodedSb.toString()));
             }
             m.appendTail(sb);
             return sb.toString();
@@ -84,7 +84,7 @@ public class CodecUtils {
             StringBuilder sb = new StringBuilder(encoded.length());
             while (m.find()) {
                 String chars = m.group(0);
-                m.appendReplacement(sb, new String(parseBytes(chars), encoding));
+                m.appendReplacement(sb, Matcher.quoteReplacement(new String(parseBytes(chars), encoding)));
             }
             m.appendTail(sb);
             return sb.toString();

--- a/enkan-web/src/test/java/enkan/util/CodecUtilsTest.java
+++ b/enkan-web/src/test/java/enkan/util/CodecUtilsTest.java
@@ -30,6 +30,27 @@ public class CodecUtilsTest {
     }
 
     @Test
+    public void urlDecode() {
+        assertThat(CodecUtils.urlDecode("abc%e3%81%82def"))
+                .isEqualTo("abcあdef");
+    }
+
+    @Test
+    public void urlDecodeWithDollarSign() {
+        // %24 decodes to '$', which is special in Matcher.appendReplacement if not quoted.
+        assertThat(CodecUtils.urlDecode("%24")).isEqualTo("$");
+        assertThat(CodecUtils.urlDecode("%241")).isEqualTo("$1");
+        assertThat(CodecUtils.urlDecode("price%3D%241")).isEqualTo("price=$1");
+    }
+
+    @Test
+    public void urlDecodeWithBackslash() {
+        // %5C decodes to '\', which is special in Matcher.appendReplacement if not quoted.
+        assertThat(CodecUtils.urlDecode("%5C")).isEqualTo("\\");
+        assertThat(CodecUtils.urlDecode("a%5Cb")).isEqualTo("a\\b");
+    }
+
+    @Test
     public void formEncode() {
         Map<String, Object> m = new HashMap<>();
         m.put("a", null);


### PR DESCRIPTION
## Summary

- `Matcher.appendReplacement(sb, replacement)` treats `$` and `\` as special characters in the replacement string (`$0`/`$1` for group references, `\` as escape character)
- `urlDecode()` passed the decoded string directly — if a URL-encoded value decodes to `$` (`%24`) or `\` (`%5C`), the output was wrong or an `IllegalArgumentException` was thrown
- `urlEncode()` output is `%xx` only, so safe in practice, but fixed for consistency
- Applied `Matcher.quoteReplacement()` to both call sites

## Test plan

- [x] `urlDecodeWithDollarSign()` — `%24` → `"$"`, `%241` → `"$1"`, `price%3D%241` → `"price=$1"`
- [x] `urlDecodeWithBackslash()` — `%5C` → `"\\"`, `a%5Cb` → `"a\\b"`
- [x] Existing `urlEncode` and `parseBytes` tests pass

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)