### PR TITLE
docs: document redirect status code method-change semantics per RFC 7231

### DIFF
--- a/enkan-web/src/main/java/enkan/util/HttpResponseUtils.java
+++ b/enkan-web/src/main/java/enkan/util/HttpResponseUtils.java
@@ -57,7 +57,7 @@ public class HttpResponseUtils {
 
         /**
          * 303 See Other (RFC 7231 §6.4.4).
-         * The response to the redirect MUST be retrieved with GET.
+         * The response to the redirect MUST be retrieved with GET or HEAD.
          * Commonly used after a POST form submission to redirect to a result page.
          */
         SEE_OTHER(303),


### PR DESCRIPTION
## Summary
- Adds Javadoc to all five `RedirectStatusCode` enum constants clarifying which codes are method-changing (301, 302, 303) and which are method-preserving (307, 308), with RFC 7231 §6.4 and RFC 7538 §3 references
- Adds an enum-level Javadoc explaining the two categories at a glance
- Adds a method-change warning to `redirect()` Javadoc pointing developers to 307/308 when method preservation is needed
- No logic changes

## Test plan
- [ ] All existing `enkan-web` tests pass (no logic change)

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)