### PR TITLE
fix: prevent NPE in bestAllowedEncoding when wildcard is absent

### DIFF
--- a/enkan-web/src/main/java/enkan/middleware/negotiation/AcceptHeaderNegotiator.java
+++ b/enkan-web/src/main/java/enkan/middleware/negotiation/AcceptHeaderNegotiator.java
@@ -167,9 +167,12 @@ public class AcceptHeaderNegotiator implements ContentNegotiator {
                         AcceptFragment::q));
         available = new HashSet<>(available);
         available.add("identity");
-        return selectBest(available, encoding ->
-                accepts.getOrDefault(encoding,
-                        accepts.get("*")))
+        Double wildcardQ = accepts.get("*");
+        return selectBest(available, encoding -> {
+            Double q = accepts.get(encoding);
+            if (q != null) return q;
+            return wildcardQ != null ? wildcardQ : 0.0;
+        })
                 .orElseGet(() -> {
                     if (! (accepts.getOrDefault("identity", 1.0) == 0.0
                             || (accepts.getOrDefault("*", 1.0) == 0 && !accepts.containsKey("identity")))) {

--- a/enkan-web/src/test/java/enkan/middleware/negotiation/AcceptHeaderNegotiatorTest.java
+++ b/enkan-web/src/test/java/enkan/middleware/negotiation/AcceptHeaderNegotiatorTest.java
@@ -161,4 +161,42 @@ class AcceptHeaderNegotiatorTest {
         assertThat(mt).isNotNull();
         assertThat(mt.getSubtype()).isEqualTo("plain");
     }
+
+    @Test
+    void encodingNegotiationWithoutWildcardDoesNotThrow() {
+        // Accept-Encoding: gzip with no wildcard — must not NPE
+        Set<String> available = new HashSet<>(Arrays.asList("deflate"));
+        String enc = neg.bestAllowedEncoding("gzip", available);
+        assertThat(enc).isEqualTo("identity");
+    }
+
+    @Test
+    void encodingNegotiationWithWildcard() {
+        Set<String> available = new HashSet<>(Arrays.asList("gzip", "br"));
+        String enc = neg.bestAllowedEncoding("*;q=0.5, gzip;q=1.0", available);
+        assertThat(enc).isEqualTo("gzip");
+    }
+
+    @Test
+    void encodingNegotiationExactMatch() {
+        Set<String> available = new HashSet<>(Arrays.asList("gzip", "deflate"));
+        String enc = neg.bestAllowedEncoding("gzip;q=1.0, deflate;q=0.5", available);
+        assertThat(enc).isEqualTo("gzip");
+    }
+
+    @Test
+    void encodingFallsBackToIdentity() {
+        // br accepted but not available, gzip available but not accepted
+        Set<String> available = new HashSet<>(Arrays.asList("gzip"));
+        String enc = neg.bestAllowedEncoding("br", available);
+        assertThat(enc).isEqualTo("identity");
+    }
+
+    @Test
+    void encodingReturnsNullWhenIdentityRejected() {
+        // identity explicitly rejected, no matching encoding available
+        Set<String> available = new HashSet<>(Arrays.asList("deflate"));
+        String enc = neg.bestAllowedEncoding("gzip, identity;q=0", available);
+        assertThat(enc).isNull();
+    }
 }


### PR DESCRIPTION
## Summary

- Fix `NullPointerException` in `AcceptHeaderNegotiator.bestAllowedEncoding()` when Accept-Encoding header does not contain `*` wildcard
- Extract `wildcardQ` before the scoring lambda and default to `0.0` when both the encoding and wildcard are absent
- Root cause: `accepts.getOrDefault(encoding, accepts.get("*"))` returns `null` when neither key exists, which is then unboxed to `double`

Closes #110

## Test plan

- [x] `encodingNegotiationWithoutWildcardDoesNotThrow` — NPE regression test: `Accept-Encoding: gzip` with available `["deflate"]` returns `"identity"`
- [x] `encodingNegotiationWithWildcard` — wildcard present: `gzip;q=1.0` preferred over `*;q=0.5`
- [x] `encodingNegotiationExactMatch` — exact match: `gzip;q=1.0` preferred over `deflate;q=0.5`
- [x] `encodingFallsBackToIdentity` — no match: falls back to `"identity"`
- [x] `encodingReturnsNullWhenIdentityRejected` — `identity;q=0` explicitly rejected → returns `null`
- [x] All 19 AcceptHeaderNegotiator tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)