### PR TITLE
feat: add opt-in charset/encoding negotiation to ContentNegotiationMiddleware

### DIFF
--- a/enkan-web/src/main/java/enkan/data/ContentNegotiable.java
+++ b/enkan-web/src/main/java/enkan/data/ContentNegotiable.java
@@ -22,4 +22,20 @@ public interface ContentNegotiable extends Extendable {
     default void setLocale(Locale locale) {
         setExtension("locale", locale);
     }
+
+    default String getCharset() {
+        return getExtension("charset");
+    }
+
+    default void setCharset(String charset) {
+        setExtension("charset", charset);
+    }
+
+    default String getEncoding() {
+        return getExtension("encoding");
+    }
+
+    default void setEncoding(String encoding) {
+        setExtension("encoding", encoding);
+    }
 }

--- a/enkan-web/src/main/java/enkan/middleware/ContentNegotiationMiddleware.java
+++ b/enkan-web/src/main/java/enkan/middleware/ContentNegotiationMiddleware.java
@@ -27,6 +27,8 @@ public class ContentNegotiationMiddleware implements WebMiddleware {
     private ContentNegotiator negotiator;
     private Set<String> allowedTypes;
     private Set<String> allowedLanguages;
+    private Set<String> allowedCharsets;
+    private Set<String> allowedEncodings;
 
     public ContentNegotiationMiddleware() {
         negotiator = new AcceptHeaderNegotiator();
@@ -46,6 +48,20 @@ public class ContentNegotiationMiddleware implements WebMiddleware {
         request = MixinUtils.mixin(request, ContentNegotiable.class);
         ((ContentNegotiable) request).setMediaType(mediaType);
         ((ContentNegotiable) request).setLocale(locale);
+
+        if (allowedCharsets != null) {
+            String acceptCharset = headers != null
+                    ? Objects.toString(headers.getOrDefault("Accept-Charset", "*"), "*") : "*";
+            String charset = negotiator.bestAllowedCharset(acceptCharset, allowedCharsets);
+            ((ContentNegotiable) request).setCharset(charset);
+        }
+        if (allowedEncodings != null) {
+            String acceptEncoding = headers != null
+                    ? Objects.toString(headers.getOrDefault("Accept-Encoding", "identity"), "identity") : "identity";
+            String encoding = negotiator.bestAllowedEncoding(acceptEncoding, allowedEncodings);
+            ((ContentNegotiable) request).setEncoding(encoding);
+        }
+
         return castToHttpResponse(chain.next(request));
     }
 
@@ -59,5 +75,13 @@ public class ContentNegotiationMiddleware implements WebMiddleware {
 
     public void setAllowedLanguages(Set<String> allowedLanguages) {
         this.allowedLanguages = Set.copyOf(allowedLanguages);
+    }
+
+    public void setAllowedCharsets(Set<String> allowedCharsets) {
+        this.allowedCharsets = allowedCharsets != null ? Set.copyOf(allowedCharsets) : null;
+    }
+
+    public void setAllowedEncodings(Set<String> allowedEncodings) {
+        this.allowedEncodings = allowedEncodings != null ? Set.copyOf(allowedEncodings) : null;
     }
 }

--- a/enkan-web/src/test/java/enkan/middleware/ContentNegotiationMiddlewareTest.java
+++ b/enkan-web/src/test/java/enkan/middleware/ContentNegotiationMiddlewareTest.java
@@ -145,6 +145,76 @@ class ContentNegotiationMiddlewareTest {
     }
 
     @Test
+    void charsetAndEncodingNotNegotiatedByDefault() {
+        request = builder(new DefaultHttpRequest())
+                .set(HttpRequest::setHeaders, Headers.of(
+                        "Accept", "text/html",
+                        "Accept-Charset", "utf-8",
+                        "Accept-Encoding", "gzip"))
+                .build();
+        MiddlewareChain<HttpRequest, HttpResponse, ?, ?> chain = new DefaultMiddlewareChain<>(new AnyPredicate<>(), null,
+                (Endpoint<HttpRequest, HttpResponse>) req -> {
+                    ContentNegotiable cn = (ContentNegotiable) req;
+                    assertThat(cn.getCharset()).isNull();
+                    assertThat(cn.getEncoding()).isNull();
+                    return HttpResponse.of("ok");
+                });
+        middleware.handle(request, chain);
+    }
+
+    @Test
+    void charsetNegotiatedWhenConfigured() {
+        middleware.setAllowedCharsets(Set.of("utf-8", "iso-8859-1"));
+        request = builder(new DefaultHttpRequest())
+                .set(HttpRequest::setHeaders, Headers.of(
+                        "Accept", "text/html",
+                        "Accept-Charset", "utf-8"))
+                .build();
+        MiddlewareChain<HttpRequest, HttpResponse, ?, ?> chain = new DefaultMiddlewareChain<>(new AnyPredicate<>(), null,
+                (Endpoint<HttpRequest, HttpResponse>) req -> {
+                    assertThat(((ContentNegotiable) req).getCharset()).isEqualTo("utf-8");
+                    return HttpResponse.of("ok");
+                });
+        middleware.handle(request, chain);
+    }
+
+    @Test
+    void encodingNegotiatedWhenConfigured() {
+        middleware.setAllowedEncodings(Set.of("gzip", "deflate"));
+        request = builder(new DefaultHttpRequest())
+                .set(HttpRequest::setHeaders, Headers.of(
+                        "Accept", "text/html",
+                        "Accept-Encoding", "gzip"))
+                .build();
+        MiddlewareChain<HttpRequest, HttpResponse, ?, ?> chain = new DefaultMiddlewareChain<>(new AnyPredicate<>(), null,
+                (Endpoint<HttpRequest, HttpResponse>) req -> {
+                    assertThat(((ContentNegotiable) req).getEncoding()).isEqualTo("gzip");
+                    return HttpResponse.of("ok");
+                });
+        middleware.handle(request, chain);
+    }
+
+    @Test
+    void charsetAndEncodingBothConfigured() {
+        middleware.setAllowedCharsets(Set.of("utf-8"));
+        middleware.setAllowedEncodings(Set.of("gzip"));
+        request = builder(new DefaultHttpRequest())
+                .set(HttpRequest::setHeaders, Headers.of(
+                        "Accept", "text/html",
+                        "Accept-Charset", "utf-8",
+                        "Accept-Encoding", "gzip"))
+                .build();
+        MiddlewareChain<HttpRequest, HttpResponse, ?, ?> chain = new DefaultMiddlewareChain<>(new AnyPredicate<>(), null,
+                (Endpoint<HttpRequest, HttpResponse>) req -> {
+                    ContentNegotiable cn = (ContentNegotiable) req;
+                    assertThat(cn.getCharset()).isEqualTo("utf-8");
+                    assertThat(cn.getEncoding()).isEqualTo("gzip");
+                    return HttpResponse.of("ok");
+                });
+        middleware.handle(request, chain);
+    }
+
+    @Test
     void acceptLanguageWithRegionFallsBackToLanguage() {
         middleware.setAllowedLanguages(new HashSet<>(Collections.singletonList("en")));
         request = builder(new DefaultHttpRequest())


### PR DESCRIPTION
## Summary

- Add `allowedCharsets` and `allowedEncodings` configuration to `ContentNegotiationMiddleware` (default `null` = no negotiation, backward compatible)
- When configured, negotiate `Accept-Charset` / `Accept-Encoding` headers and store results on the request
- Add `getCharset()`/`setCharset()`/`getEncoding()`/`setEncoding()` to `ContentNegotiable` interface
- All `ContentNegotiator` methods are now reachable from the middleware, eliminating dead code

Closes #112

## Usage

```java
ContentNegotiationMiddleware cnm = new ContentNegotiationMiddleware();
cnm.setAllowedCharsets(Set.of("utf-8", "iso-8859-1"));   // opt-in
cnm.setAllowedEncodings(Set.of("gzip", "deflate"));       // opt-in
```

## Test plan

- [x] `charsetAndEncodingNotNegotiatedByDefault` — null by default, backward compatible
- [x] `charsetNegotiatedWhenConfigured` — `Accept-Charset: utf-8` → `getCharset()` = `"utf-8"`
- [x] `encodingNegotiatedWhenConfigured` — `Accept-Encoding: gzip` → `getEncoding()` = `"gzip"`
- [x] `charsetAndEncodingBothConfigured` — both set together
- [x] All 11 ContentNegotiationMiddleware tests pass (7 existing + 4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)