### PR TITLE
fix: add 308 Permanent Redirect to AbsoluteRedirectsMiddleware

### DIFF
--- a/enkan-web/src/main/java/enkan/middleware/AbsoluteRedirectsMiddleware.java
+++ b/enkan-web/src/main/java/enkan/middleware/AbsoluteRedirectsMiddleware.java
@@ -27,7 +27,7 @@ import static enkan.util.HttpRequestUtils.requestUrl;
  */
 @Middleware(name = "absoluteRedirect")
 public class AbsoluteRedirectsMiddleware implements WebMiddleware {
-    private static final Set<Integer> REDIRECT_STATUS = new HashSet<>(Arrays.asList(201, 301, 302, 303, 307));
+    private static final Set<Integer> REDIRECT_STATUS = new HashSet<>(Arrays.asList(201, 301, 302, 303, 307, 308));
 
     /**
      * Returns {@code true} if the response status is one of the redirect codes

--- a/enkan-web/src/test/java/enkan/middleware/AbsoluteRedirectsMiddlewareTest.java
+++ b/enkan-web/src/test/java/enkan/middleware/AbsoluteRedirectsMiddlewareTest.java
@@ -59,4 +59,18 @@ class AbsoluteRedirectsMiddlewareTest {
         assertThat(response.getHeaders().get("Location"))
                 .isEqualTo("http://example.com/prefix/foo/bar");
     }
+
+    @Test
+    void permanentRedirect308() {
+        MiddlewareChain<HttpRequest, HttpResponse, ?, ?> chain = new DefaultMiddlewareChain<>(new AnyPredicate<>(), null,
+                (Endpoint<HttpRequest, HttpResponse>) req ->
+                        builder(HttpResponse.of("hello"))
+                                .set(HttpResponse::setStatus, 308)
+                                .set(HttpResponse::setHeaders, Headers.of("Location", "/new-path"))
+                                .build());
+
+        HttpResponse response = middleware.handle(request, chain);
+        assertThat(response.getHeaders().get("Location"))
+                .isEqualTo("http://example.com/new-path");
+    }
 }


### PR DESCRIPTION
## Summary

Add status code 308 (Permanent Redirect, RFC 7538) to `AbsoluteRedirectsMiddleware.REDIRECT_STATUS` so that relative Location headers in 308 responses are resolved to absolute URLs.

Closes #103

## Test plan

- [x] `permanentRedirect308` — 308 response with relative Location `/new-path` resolved to `http://example.com/new-path`
- [x] All 3 AbsoluteRedirectsMiddleware tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)