### PR TITLE
feat: add COEP and Permissions-Policy to SecurityHeadersMiddleware

### DIFF
--- a/enkan-web/src/main/java/enkan/middleware/SecurityHeadersMiddleware.java
+++ b/enkan-web/src/main/java/enkan/middleware/SecurityHeadersMiddleware.java
@@ -28,11 +28,7 @@ import static enkan.util.HttpResponseUtils.header;
  *   <li>{@code Cross-Origin-Opener-Policy: same-origin}</li>
  *   <li>{@code Cross-Origin-Resource-Policy: same-origin}</li>
  *   <li>{@code Cross-Origin-Embedder-Policy: require-corp}</li>
- * </ul>
- *
- * <p>The following headers are available but disabled by default (no safe universal default exists):
- * <ul>
- *   <li>{@code Permissions-Policy} — restricts browser features (camera, geolocation, etc.)</li>
+ *   <li>{@code Permissions-Policy} — disabled by default (no safe universal default exists)</li>
  * </ul>
  *
  * <h2>Usage</h2>

--- a/enkan-web/src/test/java/enkan/middleware/SecurityHeadersMiddlewareTest.java
+++ b/enkan-web/src/test/java/enkan/middleware/SecurityHeadersMiddlewareTest.java
@@ -47,11 +47,13 @@ class SecurityHeadersMiddlewareTest {
         SecurityHeadersMiddleware middleware = new SecurityHeadersMiddleware();
         middleware.setStrictTransportSecurity(null);
         middleware.setContentSecurityPolicy(null);
+        middleware.setCrossOriginEmbedderPolicy(null);
 
         HttpResponse response = middleware.handle(request, chain);
 
         assertThat(response.getHeaders().containsKey("Strict-Transport-Security")).isFalse();
         assertThat(response.getHeaders().containsKey("Content-Security-Policy")).isFalse();
+        assertThat(response.getHeaders().containsKey("Cross-Origin-Embedder-Policy")).isFalse();
         // other headers still present
         assertThat((String) getHeader(response, "X-Content-Type-Options")).isEqualTo("nosniff");
     }
@@ -65,16 +67,6 @@ class SecurityHeadersMiddlewareTest {
 
         assertThat((String) getHeader(response, "Content-Security-Policy"))
                 .isEqualTo("default-src 'self'; img-src *");
-    }
-
-    @Test
-    void coepCanBeDisabled() {
-        SecurityHeadersMiddleware middleware = new SecurityHeadersMiddleware();
-        middleware.setCrossOriginEmbedderPolicy(null);
-
-        HttpResponse response = middleware.handle(request, chain);
-
-        assertThat(response.getHeaders().containsKey("Cross-Origin-Embedder-Policy")).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add `Cross-Origin-Embedder-Policy` header (default: `require-corp`) to complete the cross-origin isolation trio (COOP + CORP + COEP), enabling `crossOriginIsolated` context in browsers
- Add `Permissions-Policy` header (disabled by default) for restricting browser features (camera, geolocation, etc.)
- Both headers follow the existing pattern: configurable string field, `null` to disable

closes #125

## Test plan

- [x] Default headers test verifies COEP is `require-corp` and Permissions-Policy is absent
- [x] COEP can be disabled by setting to `null`
- [x] COEP can be set to `credentialless`
- [x] Permissions-Policy is applied when explicitly set
- [x] All 276 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)