### PR TITLE
feat: add RequestTimeoutMiddleware

### DIFF
--- a/enkan-web/pom.xml
+++ b/enkan-web/pom.xml
@@ -32,7 +32,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>--enable-preview</argLine>
+                    <argLine>
+                        --add-opens java.base/java.lang=ALL-UNNAMED
+                        --add-opens java.base/java.lang.invoke=ALL-UNNAMED
+                        -XX:+EnableDynamicAgentLoading
+                        --enable-preview
+                    </argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/enkan-web/src/main/java/enkan/middleware/RequestTimeoutMiddleware.java
+++ b/enkan-web/src/main/java/enkan/middleware/RequestTimeoutMiddleware.java
@@ -34,11 +34,11 @@ import static enkan.util.BeanBuilder.builder;
  * </ol>
  *
  * <h2>Preview API requirement</h2>
- * <p>{@link StructuredTaskScope} is a preview API in Java 25. This class is
- * compiled with {@code --enable-preview} as part of the enkan-web build.
- * Applications that reference this class must also be <em>run</em> with
- * {@code --enable-preview}; applications that do not reference it are
- * unaffected.
+ * <p>{@link StructuredTaskScope} is a preview API in Java 25. The enkan-web
+ * module is compiled with {@code --enable-preview}, which marks its class files
+ * as preview. As a result, <em>all</em> applications that load classes from
+ * enkan-web must be run with {@code --enable-preview}, regardless of whether
+ * they use this middleware directly.
  *
  * <h2>Usage</h2>
  * <pre>{@code
@@ -89,7 +89,7 @@ public class RequestTimeoutMiddleware implements WebMiddleware {
             throw new RuntimeException(cause);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            return timeoutResponse();
+            throw new RuntimeException("Request processing interrupted", e);
         }
     }
 

--- a/enkan-web/src/test/java/enkan/middleware/RequestTimeoutMiddlewareTest.java
+++ b/enkan-web/src/test/java/enkan/middleware/RequestTimeoutMiddlewareTest.java
@@ -104,6 +104,27 @@ class RequestTimeoutMiddlewareTest {
     }
 
     @Test
+    void interruptedExceptionPropagatesAsRuntimeException() throws InterruptedException {
+        middleware.setTimeoutMillis(5_000);
+        var latch = new java.util.concurrent.CountDownLatch(1);
+        MiddlewareChain<HttpRequest, HttpResponse, ?, ?> chain = new DefaultMiddlewareChain<>(
+                new AnyPredicate<>(), null,
+                (Endpoint<HttpRequest, HttpResponse>) req -> {
+                    latch.countDown();
+                    try { Thread.sleep(10_000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+                    return HttpResponse.of("ok");
+                });
+
+        Thread testThread = Thread.ofVirtual().start(() ->
+                assertThatThrownBy(() -> middleware.handle(getRequest(), chain))
+                        .isInstanceOf(RuntimeException.class)
+                        .hasMessageContaining("interrupted"));
+        latch.await();
+        testThread.interrupt();
+        testThread.join(2_000);
+    }
+
+    @Test
     void nullResponseFromHandlerIsPassedThrough() {
         middleware.setTimeoutMillis(5_000);
         MiddlewareChain<HttpRequest, HttpResponse, ?, ?> chain = new DefaultMiddlewareChain<>(


### PR DESCRIPTION
## Summary

- Add `RequestTimeoutMiddleware` that enforces a per-request deadline using `StructuredTaskScope`
- Runs `chain.next()` in a virtual thread forked by `StructuredTaskScope`; `ScopedValue` bindings are inherited
- Returns **504 Gateway Timeout** (configurable via `setTimeoutStatus(int)`) if the handler exceeds `timeoutMillis` (default 30 s)
- Equivalent to Hono's `timeout()` middleware

## Design decisions

| Decision | Rationale |
|---|---|
| `StructuredTaskScope` (not singleton executor) | Inherits `ScopedValue` bindings from the calling thread; structured shutdown ensures subtask cannot outlive the scope |
| `--enable-preview` on enkan-web | `StructuredTaskScope` is a preview API in Java 25; all class files in the module are marked preview |
| 504 default status | Matches Hono's default; configurable via `setTimeoutStatus()` |
| Doma2 note in Javadoc | `ThreadLocal`-based transaction context is not inherited; ordering guidance documented |

## Test plan

- [x] Normal request completes before timeout → original status returned
- [x] Slow handler exceeds timeout → 504 returned
- [x] Custom status code via `setTimeoutStatus(503)`
- [x] Handler exception propagates independently of timeout
- [x] `setTimeoutMillis(0)` / negative → `MisconfigurationException`
- [x] Invalid status code (99 / 600) → `MisconfigurationException`
- [x] `InterruptedException` propagates as `RuntimeException` (not swallowed as 504)
- [x] Null response from handler passes through
- [x] `ScopedValue` binding is inherited by the subtask

🤖 Generated with [Claude Code](https://claude.com/claude-code)