### PR TITLE
fix: make timeoutMillis and timeoutStatus volatile

### DIFF
--- a/enkan-web/src/main/java/enkan/middleware/RequestTimeoutMiddleware.java
+++ b/enkan-web/src/main/java/enkan/middleware/RequestTimeoutMiddleware.java
@@ -66,8 +66,8 @@ import static enkan.util.BeanBuilder.builder;
 @Middleware(name = "requestTimeout")
 public class RequestTimeoutMiddleware implements WebMiddleware {
 
-    private long timeoutMillis = 30_000;
-    private int  timeoutStatus = 504;
+    private volatile long timeoutMillis = 30_000;
+    private volatile int  timeoutStatus = 504;
 
     @Override
     public <NNREQ, NNRES> HttpResponse handle(HttpRequest request,


### PR DESCRIPTION
## Summary

- `timeoutMillis` and `timeoutStatus` in `RequestTimeoutMiddleware` were plain fields without `volatile`
- Without `volatile`, the JMM does not guarantee visibility to the handler thread if the fields were written by a different thread at configuration time (e.g., a DI container wiring thread)
- Consistent with `ForwardedMiddleware`, which already uses `volatile` for its settable fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)