### PR TITLE
fix(graalvm): support ValidateBodyMiddleware in native image

### DIFF
--- a/kotowari-graalvm-example/pom.xml
+++ b/kotowari-graalvm-example/pom.xml
@@ -99,6 +99,16 @@
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
+        <!-- Jakarta Validation provider for native image -->
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+        </dependency>
+        <!-- EL implementation required by Hibernate Validator's message interpolator -->
+        <dependency>
+            <groupId>org.glassfish.expressly</groupId>
+            <artifactId>expressly</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
@@ -162,6 +172,9 @@
                                 <version>25</version>
                                 <vendor>GraalVM</vendor>
                             </javaToolchain>
+                            <metadataRepository>
+                                <enabled>true</enabled>
+                            </metadataRepository>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/kotowari-graalvm-example/src/main/java/kotowari/example/graalvm/NativeApplicationFactory.java
+++ b/kotowari-graalvm-example/src/main/java/kotowari/example/graalvm/NativeApplicationFactory.java
@@ -37,6 +37,7 @@ public class NativeApplicationFactory implements ApplicationFactory<HttpRequest,
             r.get("/todos").to(TodoController.class, "list");
             r.get("/todos/:id").to(TodoController.class, "show");
             r.post("/todos").to(TodoController.class, "create");
+            r.post("/todos/validate").to(TodoController.class, "createWithValidation");
             r.get("/session").to(SessionController.class, "visit");
         }).compile();
     }
@@ -84,6 +85,7 @@ public class NativeApplicationFactory implements ApplicationFactory<HttpRequest,
                 .set(SerDesMiddleware::setBodyReaders,
                         new JsonBodyReader<>(mapper))
                 .build());
+        app.use(new ValidateBodyMiddleware<>());
         app.use(new NativeControllerInvokerMiddleware<>(injector));
 
         return app;

--- a/kotowari-graalvm-example/src/main/java/kotowari/example/graalvm/controller/TodoController.java
+++ b/kotowari-graalvm-example/src/main/java/kotowari/example/graalvm/controller/TodoController.java
@@ -3,6 +3,7 @@ package kotowari.example.graalvm.controller;
 import enkan.collection.Parameters;
 import enkan.data.HttpRequest;
 import enkan.data.HttpResponse;
+import kotowari.example.graalvm.form.TodoForm;
 import kotowari.example.graalvm.model.Todo;
 
 import java.util.ArrayList;
@@ -36,6 +37,18 @@ public class TodoController {
     public Todo create(Todo todo) {
         long id = idGenerator.getAndIncrement();
         Todo created = new Todo(id, todo.title(), todo.done());
+        store.put(id, created);
+        return created;
+    }
+
+    public Object createWithValidation(TodoForm form) {
+        if (form.hasErrors()) {
+            return builder(HttpResponse.of("Validation failed"))
+                    .set(HttpResponse::setStatus, 400)
+                    .build();
+        }
+        long id = idGenerator.getAndIncrement();
+        Todo created = new Todo(id, form.getTitle(), false);
         store.put(id, created);
         return created;
     }

--- a/kotowari-graalvm-example/src/main/java/kotowari/example/graalvm/form/TodoForm.java
+++ b/kotowari-graalvm-example/src/main/java/kotowari/example/graalvm/form/TodoForm.java
@@ -1,0 +1,39 @@
+package kotowari.example.graalvm.form;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import kotowari.data.Validatable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Form object for creating a Todo item with validation.
+ * Implements Validatable so ValidateBodyMiddleware can collect constraint violations.
+ */
+public class TodoForm implements Validatable {
+    private final Map<String, Object> extensions = new HashMap<>();
+
+    @NotNull
+    @Size(min = 1, max = 100)
+    private String title;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getExtension(String name) {
+        return (T) extensions.get(name);
+    }
+
+    @Override
+    public <T> void setExtension(String name, T extension) {
+        extensions.put(name, extension);
+    }
+}

--- a/kotowari-graalvm-example/src/main/resources/META-INF/native-image/net.unit8.enkan/kotowari-graalvm-example/reachability-metadata.json
+++ b/kotowari-graalvm-example/src/main/resources/META-INF/native-image/net.unit8.enkan/kotowari-graalvm-example/reachability-metadata.json
@@ -22,6 +22,14 @@
       "methods": [
         {"name": "<init>", "parameterTypes": ["long", "java.lang.String", "boolean"]}
       ]
+    },
+    {
+      "type": "kotowari.example.graalvm.form.TodoForm",
+      "allDeclaredMethods": true,
+      "allDeclaredFields": true,
+      "methods": [
+        {"name": "<init>", "parameterTypes": []}
+      ]
     }
   ]
 }

--- a/kotowari-graalvm-example/src/main/resources/META-INF/native-image/net.unit8.enkan/kotowari-graalvm-example/reflect-config.json
+++ b/kotowari-graalvm-example/src/main/resources/META-INF/native-image/net.unit8.enkan/kotowari-graalvm-example/reflect-config.json
@@ -1,1 +1,6 @@
-[]
+[
+  {
+    "type": "org.hibernate.validator.HibernateValidator",
+    "allDeclaredConstructors": true
+  }
+]

--- a/kotowari-graalvm-example/src/main/resources/META-INF/native-image/net.unit8.enkan/kotowari-graalvm-example/resource-config.json
+++ b/kotowari-graalvm-example/src/main/resources/META-INF/native-image/net.unit8.enkan/kotowari-graalvm-example/resource-config.json
@@ -2,6 +2,7 @@
   "globs": [
     {"glob": "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"},
     {"glob": "META-INF/services/jakarta.validation.spi.ValidationProvider"},
+    {"glob": "org/hibernate/validator/ValidationMessages*.properties"},
     {"glob": "simplelogger.properties"},
     {"module": "jdk.jfr", "glob": "jdk/jfr/internal/query/view.ini"}
   ]


### PR DESCRIPTION
## Summary

- `ValidateBodyMiddleware` calls `Validation.buildDefaultValidatorFactory()` programmatically, but the GraalVM reachability metadata entry for `HibernateValidator` is gated on `ValidationBootstrapParameters` — never reachable in this code path — causing `NoClassDefFoundError` at runtime
- Registering `HibernateValidator` unconditionally in `reflect-config.json` makes it reachable, which activates 230+ `ValidatorImpl`-conditioned entries in the reachability metadata automatically
- Added `hibernate-validator` + `expressly` as runtime deps and enabled `metadataRepository` in native-maven-plugin
- Added `TodoForm` (`@NotNull @Size title`) and `POST /todos/validate` endpoint as the acceptance criteria demo

## Test plan

- [ ] `mvn test -pl kotowari-graalvm-example -am -DexcludedGroups=integration` passes
- [ ] (if GraalVM available) `mvn -pl kotowari-graalvm-example -Pnative package` builds successfully
- [ ] `curl -X POST http://localhost:3000/todos/validate -H 'Content-Type: application/json' -d '{"title":"Buy milk"}'` → 200
- [ ] `curl -X POST http://localhost:3000/todos/validate -H 'Content-Type: application/json' -d '{}'` → 400
- [ ] `curl -X POST http://localhost:3000/todos/validate -H 'Content-Type: application/json' -d '{"title":""}'` → 400

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)