### PR TITLE
feat(graalvm): auto-register all META-INF/services SPI implementations for reflection

### DIFF
--- a/kotowari-graalvm/src/main/java/kotowari/graalvm/KotowariFeature.java
+++ b/kotowari-graalvm/src/main/java/kotowari/graalvm/KotowariFeature.java
@@ -302,8 +302,13 @@ public class KotowariFeature implements Feature {
     private void parseServiceFile(Path file, ClassLoader cl, List<Class<?>> result) {
         try {
             for (String line : Files.readAllLines(file, StandardCharsets.UTF_8)) {
+                // ServiceLoader spec allows inline comments: "com.Foo # note"
+                int commentStart = line.indexOf('#');
+                if (commentStart >= 0) {
+                    line = line.substring(0, commentStart);
+                }
                 line = line.strip();
-                if (line.isEmpty() || line.startsWith("#")) continue;
+                if (line.isEmpty()) continue;
                 try {
                     result.add(Class.forName(line, false, cl));
                 } catch (ClassNotFoundException ignored) {}

--- a/kotowari-graalvm/src/test/java/kotowari/graalvm/KotowariFeatureTest.java
+++ b/kotowari-graalvm/src/test/java/kotowari/graalvm/KotowariFeatureTest.java
@@ -337,12 +337,6 @@ class KotowariFeatureTest {
 
     @Test
     void discoverServiceLoaderClasses_findsImplFromDirectoryEntry() throws Exception {
-        // Load SimpleForm via URLClassLoader with null parent so it lands in the unnamed module,
-        // matching the production scenario where application classes are on the classpath.
-        // SimpleForm is in app.* — not filtered by shouldSkipType().
-        URL classesUrl = SimpleForm.class.getProtectionDomain().getCodeSource().getLocation();
-        URLClassLoader cl = new URLClassLoader(new URL[]{classesUrl}, null);
-
         Path tmpDir = Files.createTempDirectory("spi-dir-test");
         Path svcDir = tmpDir.resolve("META-INF/services");
         Files.createDirectories(svcDir);
@@ -350,12 +344,17 @@ class KotowariFeatureTest {
                 svcDir.resolve("jakarta.ws.rs.ext.MessageBodyReader"),
                 SimpleForm.class.getName());
 
-        List<Class<?>> found = feature.discoverServiceLoaderClasses(List.of(tmpDir), cl);
+        // Load SimpleForm via URLClassLoader with null parent so it lands in the unnamed module,
+        // matching the production scenario where application classes are on the classpath.
+        // SimpleForm is in app.* — not filtered by shouldSkipType().
+        URL classesUrl = SimpleForm.class.getProtectionDomain().getCodeSource().getLocation();
+        try (URLClassLoader cl = new URLClassLoader(new URL[]{classesUrl}, null)) {
+            List<Class<?>> found = feature.discoverServiceLoaderClasses(List.of(tmpDir), cl);
 
-        assertThat(found)
-                .as("Should discover SimpleForm via META-INF/services directory entry")
-                .anyMatch(c -> c.getName().equals(SimpleForm.class.getName()));
-        cl.close();
+            assertThat(found)
+                    .as("Should discover SimpleForm via META-INF/services directory entry")
+                    .anyMatch(c -> c.getName().equals(SimpleForm.class.getName()));
+        }
     }
 
     @Test
@@ -367,11 +366,10 @@ class KotowariFeatureTest {
                 svcDir.resolve("jakarta.ws.rs.ext.MessageBodyReader"),
                 "com.example.DoesNotExist");
 
-        URLClassLoader cl = new URLClassLoader(
-                new URL[]{tmpDir.toUri().toURL()}, getClass().getClassLoader());
-
-        assertThatCode(() -> feature.discoverServiceLoaderClasses(List.of(tmpDir), cl))
-                .doesNotThrowAnyException();
-        cl.close();
+        try (URLClassLoader cl = new URLClassLoader(
+                new URL[]{tmpDir.toUri().toURL()}, getClass().getClassLoader())) {
+            assertThatCode(() -> feature.discoverServiceLoaderClasses(List.of(tmpDir), cl))
+                    .doesNotThrowAnyException();
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `KotowariFeature` now scans every `META-INF/services/<name>` file on the application classpath at native-image build time and registers each discovered implementation class for reflection automatically
- Fixes the root cause of Issue #151: any `MessageBodyReader`/`MessageBodyWriter` added via `ServiceLoader` no longer requires manual `reflect-config.json` entries
- The fix is **generic** — all SPI implementations are covered, not just SerDes types

## Design decisions

- Uses `access.getApplicationClassPath()` (`List<Path>`) for reliable scanning — avoids `ClassLoader.getResources("META-INF/services/")` which silently fails for JARs without directory entries
- Handles `FileSystemAlreadyExistsException`: reuses the existing `FileSystem` rather than opening a duplicate (GraalVM may have already opened the JAR)
- Scans only root-level `META-INF/services/` files; skips `META-INF/versions/N/` subdirs in multi-release JARs
- Framework/JDK type filtering (`shouldSkipType()`) is applied in `registerServiceLoaderImpls()`, keeping `discoverServiceLoaderClasses()` a pure, independently testable helper

## Test plan

- [ ] `discoverServiceLoaderClasses_findsImplFromDirectoryEntry` — discovers an impl registered in a temp directory services file
- [ ] `discoverServiceLoaderClasses_ignoresMissingClass` — silently skips unresolvable class names without throwing
- [ ] All 21 existing tests continue to pass: `mvn test -pl kotowari-graalvm -am -DexcludedGroups=integration`

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)