### PR TITLE
Add recent security/runtime demos to kotowari-example

### DIFF
--- a/kotowari-example/src/main/java/kotowari/example/ExampleApplicationFactory.java
+++ b/kotowari-example/src/main/java/kotowari/example/ExampleApplicationFactory.java
@@ -17,22 +17,36 @@ import enkan.middleware.doma2.DomaTransactionMiddleware;
 import enkan.middleware.opentelemetry.TracingMiddleware;
 import enkan.web.middleware.session.MemoryStore;
 import enkan.predicate.PathPredicate;
+import enkan.security.crypto.CryptoAlgorithm;
+import enkan.security.crypto.JcaVerifier;
 import enkan.web.security.backend.SessionBackend;
+import enkan.web.signature.SignatureAlgorithm;
+import enkan.web.signature.SignatureComponent;
+import enkan.web.signature.SignatureKeyResolver;
 import enkan.system.inject.ComponentInjector;
 import enkan.web.util.HttpResponseUtils;
 import kotowari.example.controller.*;
+import kotowari.example.controller.api.HttpIntegrityDemoController;
+import kotowari.example.controller.api.RecentFeaturesDemoController;
+import kotowari.example.controller.api.RecentSecurityDemoController;
 import kotowari.example.controller.api.SseController;
 import kotowari.example.controller.api.TodoApiController;
 import kotowari.example.controller.guestbook.GuestbookController;
 import kotowari.example.controller.guestbook.LoginController;
 import kotowari.example.jaxrs.JsonBodyReader;
 import kotowari.example.jaxrs.JsonBodyWriter;
+import kotowari.example.middleware.RequestTimeoutDemoMiddleware;
 import kotowari.middleware.*;
 import kotowari.middleware.serdes.ToStringBodyWriter;
 import kotowari.routing.Routes;
 import jakarta.ws.rs.ext.MessageBodyWriter;
 
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import static enkan.util.BeanBuilder.*;
 import static enkan.util.Predicates.*;
@@ -85,10 +99,71 @@ public class ExampleApplicationFactory implements ApplicationFactory<HttpRequest
             r.post("/api/todo").to(TodoApiController.class, "create");
             r.put("/api/todo/:id").to(TodoApiController.class, "update");
             r.delete("/api/todo/:id").to(TodoApiController.class, "delete");
+
+            // RFC 9530 + RFC 9421 API
+            r.get("/api/http-integrity/sample").to(HttpIntegrityDemoController.class, "sample");
+            r.post("/api/http-integrity/verify").to(HttpIntegrityDemoController.class, "verify");
+
+            // Recent features demos
+            r.get("/api/recent/idempotency/sample").to(RecentFeaturesDemoController.class, "idempotencySample");
+            r.post("/api/recent/idempotency/echo").to(RecentFeaturesDemoController.class, "idempotencyEcho");
+            r.get("/api/recent/jwt/issue").to(RecentFeaturesDemoController.class, "jwtIssue");
+            r.get("/api/recent/jwt/verify").to(RecentFeaturesDemoController.class, "jwtVerify");
+
+            // Recent security/runtime demos (HTML)
+            r.get("/recent/security/csp-nonce").to(RecentSecurityDemoController.class, "cspNoncePage");
+            r.get("/recent/security/request-timeout").to(RecentSecurityDemoController.class, "requestTimeoutPage");
+            r.get("/recent/security/fetch-metadata").to(RecentSecurityDemoController.class, "fetchMetadataPage");
+
+            // Recent security/runtime demos (JSON API)
+            r.get("/api/recent/security/timeout-echo").to(RecentSecurityDemoController.class, "timeoutEcho");
+            r.get("/api/recent/security/fetch-metadata-echo").to(RecentSecurityDemoController.class, "fetchMetadataEcho");
         }).compile();
+
+        var demoKey = new SecretKeySpec(
+                System.getenv().getOrDefault("HTTP_INTEGRITY_DEMO_SECRET", "kotowari-demo-shared-secret")
+                        .getBytes(StandardCharsets.UTF_8),
+                "HmacSHA256");
+        SignatureKeyResolver demoResolver = new SignatureKeyResolver() {
+            @Override
+            public Optional<enkan.security.crypto.Verifier> resolveVerifier(String keyId, SignatureAlgorithm algorithm) {
+                if (HttpIntegrityDemoController.KEY_ID.equals(keyId)
+                        && algorithm == SignatureAlgorithm.HMAC_SHA256) {
+                    return Optional.of(new JcaVerifier(CryptoAlgorithm.HMAC_SHA256, demoKey));
+                }
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<enkan.security.crypto.Signer> resolveSigner(String keyId, SignatureAlgorithm algorithm) {
+                return Optional.empty();
+            }
+        };
+        SignatureVerificationMiddleware integritySignature = new SignatureVerificationMiddleware(demoResolver);
+        integritySignature.setRequiredLabels(Set.of("sig1"));
+        integritySignature.setRequiredComponents(Set.of("@method", "@path", "content-digest"));
+        integritySignature.setAcceptSignature(
+                "sig1",
+                List.of(
+                        SignatureComponent.of("@method"),
+                        SignatureComponent.of("@path"),
+                        SignatureComponent.of("content-digest")
+                ),
+                SignatureAlgorithm.HMAC_SHA256,
+                HttpIntegrityDemoController.KEY_ID
+        );
+
+        MemoryStore idempotencyStore = new MemoryStore();
+        idempotencyStore.setTtlSeconds(24 * 60 * 60L);
+        IdempotencyKeyMiddleware idempotencyDemo = new IdempotencyKeyMiddleware();
+        idempotencyDemo.setStore(idempotencyStore);
+        idempotencyDemo.setMethods(Set.of("POST"));
+        RequestTimeoutDemoMiddleware recentTimeout = new RequestTimeoutDemoMiddleware(200);
+        FetchMetadataMiddleware recentFetchMetadata = new FetchMetadataMiddleware();
 
         // Enkan
         app.use(new DefaultCharsetMiddleware());
+        app.use(path("^/recent/security/csp-nonce$"), new CspNonceMiddleware());
         app.use(builder(new SecurityHeadersMiddleware())
                 .set(SecurityHeadersMiddleware::setContentSecurityPolicy,
                         "default-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; connect-src 'self' ws://localhost:*")
@@ -106,6 +181,11 @@ public class ExampleApplicationFactory implements ApplicationFactory<HttpRequest
         app.use(new NormalizationMiddleware());
         app.use(new NestedParamsMiddleware());
         app.use(new CookiesMiddleware());
+        app.use(path("^/api/http-integrity/verify$"), new DigestValidationMiddleware());
+        app.use(path("^/api/http-integrity/verify$"), integritySignature);
+        app.use(path("^/api/recent/idempotency/.*$"), idempotencyDemo);
+        app.use(path("^/api/recent/security/timeout-echo$"), recentTimeout);
+        app.use(path("^/api/recent/security/fetch-metadata-echo$"), recentFetchMetadata);
 
         app.use(builder(new SessionMiddleware())
                 .set(SessionMiddleware::setStore, new MemoryStore())

--- a/kotowari-example/src/main/java/kotowari/example/controller/api/HttpIntegrityDemoController.java
+++ b/kotowari-example/src/main/java/kotowari/example/controller/api/HttpIntegrityDemoController.java
@@ -1,0 +1,140 @@
+package kotowari.example.controller.api;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import enkan.security.crypto.CryptoAlgorithm;
+import enkan.security.crypto.JcaSigner;
+import enkan.security.crypto.Signer;
+import enkan.web.collection.Headers;
+import enkan.web.data.DefaultHttpRequest;
+import enkan.web.data.HttpRequest;
+import enkan.web.data.HttpResponse;
+import enkan.web.middleware.SignatureVerificationMiddleware;
+import enkan.web.signature.HttpMessageSignatures;
+import enkan.web.signature.SignatureAlgorithm;
+import enkan.web.signature.SignatureComponent;
+import enkan.web.signature.VerifyResult;
+import enkan.web.http.fields.digest.DigestFields;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Demonstrates RFC 9530 (Digest Fields) + RFC 9421 (HTTP Message Signatures) usage.
+ */
+public class HttpIntegrityDemoController {
+    public static final String VERIFY_PATH = "/api/http-integrity/verify";
+    public static final String SAMPLE_PAYLOAD = "{\"message\":\"hello integrity\"}";
+    public static final String KEY_ID = "demo-hmac-key";
+    private static final ObjectMapper JSON = JsonMapper.builder().build();
+
+    // Demo secret for example only. Override with HTTP_INTEGRITY_DEMO_SECRET when needed.
+    private static final SecretKey DEMO_KEY = new SecretKeySpec(
+            System.getenv().getOrDefault("HTTP_INTEGRITY_DEMO_SECRET", "kotowari-demo-shared-secret")
+                    .getBytes(StandardCharsets.UTF_8),
+            "HmacSHA256");
+
+    public HttpResponse sample(HttpRequest request) {
+        String digestHeader = DigestFields.computeDigestHeader(
+                SAMPLE_PAYLOAD.getBytes(StandardCharsets.UTF_8), "sha-256");
+
+        DefaultHttpRequest signatureTarget = new DefaultHttpRequest();
+        signatureTarget.setRequestMethod("POST");
+        signatureTarget.setUri(VERIFY_PATH);
+        signatureTarget.setScheme(request.getScheme());
+        signatureTarget.setServerName(request.getServerName());
+        signatureTarget.setServerPort(request.getServerPort());
+        signatureTarget.setHeaders(Headers.of("content-digest", digestHeader));
+
+        Signer signer = new JcaSigner(CryptoAlgorithm.HMAC_SHA256, DEMO_KEY);
+        HttpMessageSignatures.SignatureResult signed = HttpMessageSignatures.sign(
+                signatureTarget,
+                List.of(
+                        SignatureComponent.of("@method"),
+                        SignatureComponent.of("@path"),
+                        SignatureComponent.of("content-digest")
+                ),
+                SignatureAlgorithm.HMAC_SHA256,
+                signer,
+                KEY_ID,
+                "rfc-demo");
+
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("Content-Type", "application/json");
+        headers.put("Content-Digest", digestHeader);
+        headers.put("Signature-Input", "sig1=" + signed.signatureInputValue());
+        headers.put("Signature", "sig1=" + signed.signatureValue());
+
+        String targetUrl = baseUrl(request) + VERIFY_PATH;
+        String curl = "curl -i -X POST '" + targetUrl + "' "
+                + "-H 'Content-Type: application/json' "
+                + "-H 'Content-Digest: " + digestHeader + "' "
+                + "-H 'Signature-Input: sig1=" + signed.signatureInputValue() + "' "
+                + "-H 'Signature: sig1=" + signed.signatureValue() + "' "
+                + "--data-binary '" + SAMPLE_PAYLOAD + "'";
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("description", "RFC 9530 + RFC 9421 demo request to /api/http-integrity/verify");
+        response.put("algorithm", "hmac-sha256");
+        response.put("keyId", KEY_ID);
+        response.put("coveredComponents", List.of("@method", "@path", "content-digest"));
+        response.put("verifyPath", VERIFY_PATH);
+        response.put("payload", SAMPLE_PAYLOAD);
+        response.put("headers", headers);
+        response.put("curl", curl);
+        response.put("note", "The server verifies Content-Digest first, then Signature/Signature-Input.");
+        return json(response);
+    }
+
+    @SuppressWarnings("unchecked")
+    public HttpResponse verify(HttpRequest request, Object body) {
+        List<VerifyResult> results = request.getExtension(SignatureVerificationMiddleware.EXTENSION_KEY);
+        if (results == null) {
+            results = List.of();
+        }
+        List<Map<String, Object>> signatures = results.stream().map(result -> {
+            Map<String, Object> item = new LinkedHashMap<>();
+            item.put("label", result.label());
+            item.put("keyId", result.keyId());
+            item.put("algorithm", result.algorithm() != null ? result.algorithm().sfName() : null);
+            item.put("coveredValues", result.coveredValues());
+            return item;
+        }).toList();
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("verified", true);
+        response.put("signatureCount", signatures.size());
+        response.put("signatures", signatures);
+        response.put("body", body);
+        return json(response);
+    }
+
+    private static String baseUrl(HttpRequest request) {
+        String host = request.getHeaders().get("host");
+        if (host != null && !host.isBlank()) {
+            return request.getScheme() + "://" + host;
+        }
+        String scheme = request.getScheme();
+        int port = request.getServerPort();
+        String serverName = request.getServerName();
+        boolean defaultPort = ("http".equalsIgnoreCase(scheme) && port == 80)
+                || ("https".equalsIgnoreCase(scheme) && port == 443);
+        return defaultPort
+                ? scheme + "://" + serverName
+                : scheme + "://" + serverName + ":" + port;
+    }
+
+    private static HttpResponse json(Object payload) {
+        try {
+            return enkan.util.BeanBuilder.builder(HttpResponse.of(JSON.writeValueAsString(payload)))
+                    .set(HttpResponse::setContentType, "application/json")
+                    .build();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize demo response", e);
+        }
+    }
+}

--- a/kotowari-example/src/main/java/kotowari/example/controller/api/RecentFeaturesDemoController.java
+++ b/kotowari-example/src/main/java/kotowari/example/controller/api/RecentFeaturesDemoController.java
@@ -1,0 +1,152 @@
+package kotowari.example.controller.api;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import enkan.collection.Parameters;
+import enkan.web.data.HttpRequest;
+import enkan.web.data.HttpResponse;
+import enkan.web.jwt.JwsAlgorithm;
+import enkan.web.jwt.JwtHeader;
+import enkan.web.jwt.JwtProcessor;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static enkan.util.BeanBuilder.builder;
+
+/**
+ * Demos for recently added web features (JWT and Idempotency-Key).
+ */
+public class RecentFeaturesDemoController {
+    private static final ObjectMapper JSON = JsonMapper.builder().build();
+    private static final String JWT_KEY_ID = "demo-jwt-key";
+    private static final SecretKey JWT_KEY = new SecretKeySpec(
+            System.getenv().getOrDefault("JWT_DEMO_SECRET", "kotowari-demo-jwt-secret")
+                    .getBytes(StandardCharsets.UTF_8),
+            "HmacSHA256");
+
+    public HttpResponse idempotencySample(HttpRequest request) {
+        String url = baseUrl(request) + "/api/recent/idempotency/echo";
+        String key = "\"demo-idempotency-key-1\"";
+        String payload = "{\"orderId\":\"A-1001\",\"amount\":1200}";
+
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("description", "Replay-safe POST demo with Idempotency-Key middleware");
+        out.put("note", "Idempotency-Key must be a Structured Field string, so use quoted value.");
+        out.put("path", "/api/recent/idempotency/echo");
+        out.put("firstRequest",
+                "curl -i -X POST '" + url + "' "
+                        + "-H 'Content-Type: application/json' "
+                        + "-H 'Idempotency-Key: " + key + "' "
+                        + "--data-binary '" + payload + "'");
+        out.put("replayRequest",
+                "curl -i -X POST '" + url + "' "
+                        + "-H 'Content-Type: application/json' "
+                        + "-H 'Idempotency-Key: " + key + "' "
+                        + "--data-binary '" + payload + "'");
+        return json(out, 200);
+    }
+
+    public HttpResponse idempotencyEcho(Parameters params, Object body) {
+        long delayMs = Math.max(0L, params.getLong("delayMs", 0L));
+        if (delayMs > 0) {
+            try {
+                Thread.sleep(Math.min(delayMs, 10_000L));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("ok", true);
+        out.put("id", UUID.randomUUID().toString());
+        out.put("processedAt", Instant.now().toString());
+        out.put("body", body);
+        out.put("delayMs", delayMs);
+        return json(out, 200);
+    }
+
+    public HttpResponse jwtIssue(Parameters params, HttpRequest request) {
+        String sub = params.get("sub");
+        if (sub == null || sub.isBlank()) {
+            sub = "alice";
+        }
+
+        long now = Instant.now().getEpochSecond();
+        Map<String, Object> claims = new LinkedHashMap<>();
+        claims.put("sub", sub);
+        claims.put("scope", "read:demo");
+        claims.put("iat", now);
+        claims.put("exp", now + 300);
+
+        try {
+            byte[] claimsJson = JSON.writeValueAsBytes(claims);
+            String token = JwtProcessor.sign(new JwtHeader("HS256", JWT_KEY_ID), claimsJson, JWT_KEY);
+
+            String verifyUrl = baseUrl(request) + "/api/recent/jwt/verify";
+            Map<String, Object> out = new LinkedHashMap<>();
+            out.put("description", "JWT issue demo (HS256)");
+            out.put("token", token);
+            out.put("claims", claims);
+            out.put("verifyPath", "/api/recent/jwt/verify");
+            out.put("verifyRequest",
+                    "curl -i '" + verifyUrl + "' -H 'Authorization: Bearer " + token + "'");
+            return json(out, 200);
+        } catch (Exception e) {
+            return json(Map.of("ok", false, "error", "Failed to issue token"), 500);
+        }
+    }
+
+    public HttpResponse jwtVerify(HttpRequest request) {
+        String auth = request.getHeaders().get("authorization");
+        if (auth == null || !auth.startsWith("Bearer ")) {
+            return json(Map.of("ok", false, "error", "Missing Authorization: Bearer <token>"), 401);
+        }
+        String token = auth.substring("Bearer ".length()).trim();
+        byte[] payload = JwtProcessor.verify(token, JwsAlgorithm.HS256, JWT_KEY);
+        if (payload == null) {
+            return json(Map.of("ok", false, "error", "Invalid or expired JWT"), 401);
+        }
+        try {
+            Object claims = JSON.readValue(payload, Object.class);
+            Map<String, Object> out = new LinkedHashMap<>();
+            out.put("ok", true);
+            out.put("claims", claims);
+            out.put("header", JwtProcessor.decodeHeader(token));
+            return json(out, 200);
+        } catch (Exception e) {
+            return json(Map.of("ok", false, "error", "Failed to parse JWT payload"), 500);
+        }
+    }
+
+    private static HttpResponse json(Object payload, int status) {
+        try {
+            return builder(HttpResponse.of(JSON.writeValueAsString(payload)))
+                    .set(HttpResponse::setStatus, status)
+                    .set(HttpResponse::setContentType, "application/json")
+                    .build();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize JSON response", e);
+        }
+    }
+
+    private static String baseUrl(HttpRequest request) {
+        String host = request.getHeaders().get("host");
+        if (host != null && !host.isBlank()) {
+            return request.getScheme() + "://" + host;
+        }
+        String scheme = request.getScheme();
+        int port = request.getServerPort();
+        String serverName = request.getServerName();
+        boolean defaultPort = ("http".equalsIgnoreCase(scheme) && port == 80)
+                || ("https".equalsIgnoreCase(scheme) && port == 443);
+        return defaultPort
+                ? scheme + "://" + serverName
+                : scheme + "://" + serverName + ":" + port;
+    }
+}

--- a/kotowari-example/src/main/java/kotowari/example/controller/api/RecentSecurityDemoController.java
+++ b/kotowari-example/src/main/java/kotowari/example/controller/api/RecentSecurityDemoController.java
@@ -1,0 +1,94 @@
+package kotowari.example.controller.api;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import enkan.collection.Parameters;
+import enkan.web.data.HttpRequest;
+import enkan.web.data.HttpResponse;
+import enkan.web.middleware.CspNonceMiddleware;
+import kotowari.component.TemplateEngine;
+import jakarta.inject.Inject;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static enkan.util.BeanBuilder.builder;
+
+/**
+ * HTML + JSON demos for recent security/runtime middlewares.
+ */
+public class RecentSecurityDemoController {
+    public static final String CSP_NONCE_PAGE = "/recent/security/csp-nonce";
+    public static final String REQUEST_TIMEOUT_PAGE = "/recent/security/request-timeout";
+    public static final String FETCH_METADATA_PAGE = "/recent/security/fetch-metadata";
+    public static final String TIMEOUT_ECHO_API = "/api/recent/security/timeout-echo";
+    public static final String FETCH_METADATA_ECHO_API = "/api/recent/security/fetch-metadata-echo";
+
+    private static final ObjectMapper JSON = JsonMapper.builder().build();
+
+    @Inject
+    private TemplateEngine<?> templateEngine;
+
+    public HttpResponse cspNoncePage(HttpRequest request) {
+        String nonce = request.getExtension(CspNonceMiddleware.EXTENSION_KEY);
+        return templateEngine.render("recent/security/csp-nonce",
+                "nonce", nonce,
+                "apiPath", TIMEOUT_ECHO_API);
+    }
+
+    public HttpResponse requestTimeoutPage() {
+        return templateEngine.render("recent/security/request-timeout",
+                "timeoutMs", 200,
+                "apiPath", TIMEOUT_ECHO_API);
+    }
+
+    public HttpResponse fetchMetadataPage(HttpRequest request) {
+        Map<String, Object> observed = new LinkedHashMap<>();
+        observed.put("sec-fetch-site", request.getHeaders().get("sec-fetch-site"));
+        observed.put("sec-fetch-mode", request.getHeaders().get("sec-fetch-mode"));
+        observed.put("sec-fetch-dest", request.getHeaders().get("sec-fetch-dest"));
+        observed.put("sec-fetch-user", request.getHeaders().get("sec-fetch-user"));
+        return templateEngine.render("recent/security/fetch-metadata",
+                "apiPath", FETCH_METADATA_ECHO_API,
+                "observed", observed);
+    }
+
+    public HttpResponse timeoutEcho(Parameters params) {
+        long delayMs = Math.max(0L, params.getLong("delayMs", 0L));
+        try {
+            Thread.sleep(delayMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return json(Map.of("ok", false, "error", "Interrupted"), 500);
+        }
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("ok", true);
+        body.put("delayMs", delayMs);
+        body.put("message", "Completed within timeout middleware constraints");
+        return json(body, 200);
+    }
+
+    public HttpResponse fetchMetadataEcho(HttpRequest request) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("ok", true);
+        body.put("requestMethod", request.getRequestMethod());
+        body.put("uri", request.getUri());
+        body.put("secFetchSite", request.getHeaders().get("sec-fetch-site"));
+        body.put("secFetchMode", request.getHeaders().get("sec-fetch-mode"));
+        body.put("secFetchDest", request.getHeaders().get("sec-fetch-dest"));
+        body.put("note", "If this endpoint returns 200, FetchMetadataMiddleware allowed the request.");
+        return json(body, 200);
+    }
+
+    private static HttpResponse json(Object payload, int status) {
+        try {
+            return builder(HttpResponse.of(JSON.writeValueAsString(payload)))
+                    .set(HttpResponse::setStatus, status)
+                    .set(HttpResponse::setContentType, "application/json")
+                    .build();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize JSON response", e);
+        }
+    }
+}

--- a/kotowari-example/src/main/java/kotowari/example/middleware/RequestTimeoutDemoMiddleware.java
+++ b/kotowari-example/src/main/java/kotowari/example/middleware/RequestTimeoutDemoMiddleware.java
@@ -1,0 +1,51 @@
+package kotowari.example.middleware;
+
+import enkan.MiddlewareChain;
+import enkan.web.data.HttpRequest;
+import enkan.web.data.HttpResponse;
+import enkan.web.middleware.WebMiddleware;
+
+import java.lang.reflect.Method;
+
+/**
+ * Reflection-based adapter for RequestTimeoutMiddleware to avoid compile-time
+ * dependency on preview class files.
+ */
+public class RequestTimeoutDemoMiddleware implements WebMiddleware {
+    private final long timeoutMillis;
+    private volatile Object delegate;
+
+    public RequestTimeoutDemoMiddleware(long timeoutMillis) {
+        this.timeoutMillis = timeoutMillis;
+    }
+
+    @Override
+    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request,
+            MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
+        Object middleware = ensureDelegate();
+        try {
+            Method handle = middleware.getClass()
+                    .getMethod("handle", HttpRequest.class, MiddlewareChain.class);
+            return (HttpResponse) handle.invoke(middleware, request, chain);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to delegate to RequestTimeoutMiddleware", e);
+        }
+    }
+
+    private Object ensureDelegate() {
+        if (delegate != null) return delegate;
+        synchronized (this) {
+            if (delegate != null) return delegate;
+            try {
+                Class<?> clazz = Class.forName("enkan.web.middleware.RequestTimeoutMiddleware");
+                Object instance = clazz.getConstructor().newInstance();
+                Method setter = clazz.getMethod("setTimeoutMillis", long.class);
+                setter.invoke(instance, timeoutMillis);
+                delegate = instance;
+                return instance;
+            } catch (ReflectiveOperationException e) {
+                throw new RuntimeException("Failed to initialize RequestTimeoutMiddleware delegate", e);
+            }
+        }
+    }
+}

--- a/kotowari-example/src/main/resources/public/js/recent-security-fetch-metadata.js
+++ b/kotowari-example/src/main/resources/public/js/recent-security-fetch-metadata.js
@@ -1,0 +1,14 @@
+(() => {
+  const script = document.currentScript;
+  const apiPath = script ? script.dataset.apiPath : null;
+  const result = document.getElementById("fetch-result");
+  const button = document.getElementById("fetch-btn");
+
+  if (!apiPath || !result || !button) return;
+
+  button.addEventListener("click", async () => {
+    const res = await fetch(apiPath);
+    const text = await res.text();
+    result.textContent = `status=${res.status}\n${text}`;
+  });
+})();

--- a/kotowari-example/src/main/resources/public/js/recent-security-request-timeout.js
+++ b/kotowari-example/src/main/resources/public/js/recent-security-request-timeout.js
@@ -1,0 +1,18 @@
+(() => {
+  const script = document.currentScript;
+  const apiPath = script ? script.dataset.apiPath : null;
+  const result = document.getElementById("timeout-result");
+  const okBtn = document.getElementById("ok-btn");
+  const timeoutBtn = document.getElementById("timeout-btn");
+
+  if (!apiPath || !result || !okBtn || !timeoutBtn) return;
+
+  async function run(delayMs) {
+    const res = await fetch(`${apiPath}?delayMs=${delayMs}`);
+    const text = await res.text();
+    result.textContent = `status=${res.status}\n${text}`;
+  }
+
+  okBtn.addEventListener("click", () => run(50));
+  timeoutBtn.addEventListener("click", () => run(1000));
+})();

--- a/kotowari-example/src/main/resources/templates/index.ftl
+++ b/kotowari-example/src/main/resources/templates/index.ftl
@@ -9,7 +9,14 @@
     <li><a href="${urlFor("kotowari.example.controller.ConversationStateController", "page1")}">Conversation</a></li>
   </ul>
   <hr/>
+  <h3>Recent Security/Runtime Demos</h3>
   <ul>
+    <li><a href="/api/http-integrity/sample">HTTP Integrity demo (RFC 9530 + RFC 9421)</a></li>
+    <li><a href="/api/recent/idempotency/sample">Idempotency-Key demo</a></li>
+    <li><a href="/api/recent/jwt/issue">JWT demo (issue token)</a></li>
+    <li><a href="/recent/security/csp-nonce">CSP Nonce demo</a></li>
+    <li><a href="/recent/security/request-timeout">Request Timeout demo</a></li>
+    <li><a href="/recent/security/fetch-metadata">Fetch Metadata demo</a></li>
     <li><a href="${urlFor("kotowari.example.controller.HospitalityDemoController", "misconfiguration")}">Misconfiguration demo</a></li>
     <li><a href="${urlFor("kotowari.example.controller.HospitalityDemoController", "unreachable")}">Unreachable Exception demo</a></li>
   </ul>

--- a/kotowari-example/src/main/resources/templates/recent/security/csp-nonce.ftl
+++ b/kotowari-example/src/main/resources/templates/recent/security/csp-nonce.ftl
@@ -1,0 +1,29 @@
+<#import "layout/defaultLayout.ftl" as layout>
+<@layout.layout "CSP Nonce Demo">
+  <h1>CSP Nonce Demo</h1>
+  <p>このページは <code>CspNonceMiddleware</code> を <code>/recent/security/csp-nonce</code> のみに適用しています。</p>
+
+  <h3>Observed Nonce</h3>
+  <p><code>${nonce!""}</code></p>
+
+  <h3>Inline Script Check</h3>
+  <p id="nonce-status">Inline script not executed yet.</p>
+  <script nonce="${nonce!""}">
+    document.getElementById("nonce-status").textContent =
+      "Inline script executed with nonce: ${nonce!""}";
+  </script>
+
+  <h3>Try</h3>
+  <ol>
+    <li>開発者ツールでレスポンスヘッダ <code>Content-Security-Policy</code> を確認</li>
+    <li><code>script-src</code> に <code>'nonce-${nonce!""}'</code> が含まれることを確認</li>
+    <li>上記ステータスが更新されることを確認</li>
+  </ol>
+
+  <h3>Expected</h3>
+  <ul>
+    <li>HTTP 200</li>
+    <li>CSP ヘッダに nonce が付与される</li>
+    <li>nonce付き inline script は実行される</li>
+  </ul>
+</@layout.layout>

--- a/kotowari-example/src/main/resources/templates/recent/security/fetch-metadata.ftl
+++ b/kotowari-example/src/main/resources/templates/recent/security/fetch-metadata.ftl
@@ -1,0 +1,26 @@
+<#import "layout/defaultLayout.ftl" as layout>
+<@layout.layout "Fetch Metadata Demo">
+  <h1>Fetch Metadata Demo</h1>
+  <p>このデモでは <code>FetchMetadataMiddleware</code> を
+    <code>${apiPath}</code> にのみ適用しています（allow-list なし）。</p>
+
+  <h3>Observed Headers On This Page Request</h3>
+  <pre>${observed?string}</pre>
+
+  <h3>Try (Same-origin browser request)</h3>
+  <button id="fetch-btn" class="btn btn-primary">Call protected API</button>
+  <pre id="fetch-result" style="margin-top: 12px;">No request yet.</pre>
+
+  <script src="/js/recent-security-fetch-metadata.js" data-api-path="${apiPath}"></script>
+
+  <h3>Cross-site Reproduction (curl)</h3>
+  <pre>curl -i "http://localhost:3000${apiPath}" \
+  -H "Sec-Fetch-Site: cross-site" \
+  -H "Sec-Fetch-Mode: cors"</pre>
+
+  <h3>Expected</h3>
+  <ul>
+    <li>Sec-Fetch ヘッダなし: 200（後方互換）</li>
+    <li><code>Sec-Fetch-Site: cross-site</code> + 非 navigate: 403</li>
+  </ul>
+</@layout.layout>

--- a/kotowari-example/src/main/resources/templates/recent/security/request-timeout.ftl
+++ b/kotowari-example/src/main/resources/templates/recent/security/request-timeout.ftl
@@ -1,0 +1,26 @@
+<#import "layout/defaultLayout.ftl" as layout>
+<@layout.layout "Request Timeout Demo">
+  <h1>Request Timeout Demo</h1>
+  <p>このデモでは <code>RequestTimeoutMiddleware</code> を
+    <code>/api/recent/security/timeout-echo</code> のみに適用し、timeout を <code>${timeoutMs}</code>ms に設定しています。</p>
+
+  <h3>API</h3>
+  <p><code>${apiPath}</code></p>
+
+  <h3>Try (curl)</h3>
+  <pre>curl -i "http://localhost:3000${apiPath}?delayMs=50"</pre>
+  <pre>curl -i "http://localhost:3000${apiPath}?delayMs=1000"</pre>
+
+  <h3>Browser Quick Test</h3>
+  <button id="ok-btn" class="btn btn-primary">delayMs=50 (expect 200)</button>
+  <button id="timeout-btn" class="btn btn-danger">delayMs=1000 (expect 504)</button>
+  <pre id="timeout-result" style="margin-top: 12px;">No request yet.</pre>
+
+  <script src="/js/recent-security-request-timeout.js" data-api-path="${apiPath}"></script>
+
+  <h3>Expected</h3>
+  <ul>
+    <li><code>delayMs=50</code> は 200</li>
+    <li><code>delayMs=1000</code> は 504 Gateway Timeout</li>
+  </ul>
+</@layout.layout>


### PR DESCRIPTION
## Summary
- add HTML+API demos for recently added middleware features in kotowari-example
  - CSP Nonce (`CspNonceMiddleware`)
  - Request Timeout (`RequestTimeoutMiddleware` behavior via demo adapter)
  - Fetch Metadata (`FetchMetadataMiddleware`)
- keep and wire existing recent demos for HTTP Integrity (RFC 9530 + RFC 9421), Idempotency-Key, and JWT
- add index links for recent security/runtime demos

## Implementation details
- New controller: `RecentSecurityDemoController`
  - HTML pages:
    - `GET /recent/security/csp-nonce`
    - `GET /recent/security/request-timeout`
    - `GET /recent/security/fetch-metadata`
  - JSON APIs:
    - `GET /api/recent/security/timeout-echo`
    - `GET /api/recent/security/fetch-metadata-echo`
- Middleware scoping in `ExampleApplicationFactory`
  - `CspNonceMiddleware` only for `/recent/security/csp-nonce`
  - request-timeout demo only for `/api/recent/security/timeout-echo` (200ms)
  - `FetchMetadataMiddleware` only for `/api/recent/security/fetch-metadata-echo`
- Added templates and small external JS files for browser interaction demos

## Build check
- `mvn -q -pl kotowari-example -am -DskipTests compile`
