### PR TITLE
chore: bump version to 0.15.1-SNAPSHOT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ All code, comments, commit messages, and documentation MUST be written in **Engl
 ## Overview
 
 Enkan is a middleware-chain-based web framework for Java 25.
-Maven multi-module project (`enkan-parent` version `0.15.0`).
+Maven multi-module project (`enkan-parent` version `0.15.1-SNAPSHOT`).
 
 ## Module Structure
 

--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ If you prefer to wire everything by hand, add the dependencies to your `pom.xml`
 <dependency>
   <groupId>net.unit8.enkan</groupId>
   <artifactId>kotowari</artifactId>
-  <version>0.15.0</version>
+  <version>0.15.1-SNAPSHOT</version>
 </dependency>
 <dependency>
   <groupId>net.unit8.enkan</groupId>
   <artifactId>enkan-component-jetty</artifactId>
-  <version>0.15.0</version>
+  <version>0.15.1-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/benchmark/enkan-app/pom.xml
+++ b/benchmark/enkan-app/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <enkan.version>0.15.0</enkan.version>
+        <enkan.version>0.15.1-SNAPSHOT</enkan.version>
     </properties>
 
     <dependencies>

--- a/docs/src/content/getting-started.md
+++ b/docs/src/content/getting-started.md
@@ -152,12 +152,12 @@ server component to your `pom.xml`:
 <dependency>
   <groupId>net.unit8.enkan</groupId>
   <artifactId>kotowari</artifactId>
-  <version>0.15.0</version>
+  <version>0.15.1-SNAPSHOT</version>
 </dependency>
 <dependency>
   <groupId>net.unit8.enkan</groupId>
   <artifactId>enkan-component-jetty</artifactId>
-  <version>0.15.0</version>
+  <version>0.15.1-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/docs/src/content/guide/graalvm.md
+++ b/docs/src/content/guide/graalvm.md
@@ -29,7 +29,7 @@ implementations that automate the reflection configuration required for a native
 <dependency>
   <groupId>net.unit8.enkan</groupId>
   <artifactId>kotowari-graalvm</artifactId>
-  <version>0.15.0</version>
+  <version>0.15.1-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/enkan-component-HikariCP/pom.xml
+++ b/enkan-component-HikariCP/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>enkan-component-HikariCP</artifactId>

--- a/enkan-component-doma2/pom.xml
+++ b/enkan-component-doma2/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>enkan-component-doma2</artifactId>

--- a/enkan-component-eclipselink/pom.xml
+++ b/enkan-component-eclipselink/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>enkan-component-eclipselink</artifactId>

--- a/enkan-component-flyway/pom.xml
+++ b/enkan-component-flyway/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>enkan-component-flyway</artifactId>

--- a/enkan-component-freemarker/pom.xml
+++ b/enkan-component-freemarker/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>enkan-component-freemarker</artifactId>

--- a/enkan-component-jackson/pom.xml
+++ b/enkan-component-jackson/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>enkan-component-jackson</artifactId>

--- a/enkan-component-jetty/pom.xml
+++ b/enkan-component-jetty/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>enkan-component-jetty</artifactId>

--- a/enkan-component-jooq/pom.xml
+++ b/enkan-component-jooq/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>enkan-component-jooq</artifactId>

--- a/enkan-component-jpa/pom.xml
+++ b/enkan-component-jpa/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>enkan-component-jpa</artifactId>

--- a/enkan-component-metrics/pom.xml
+++ b/enkan-component-metrics/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>enkan-component-metrics</artifactId>

--- a/enkan-component-micrometer/pom.xml
+++ b/enkan-component-micrometer/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>enkan-component-micrometer</artifactId>

--- a/enkan-component-opentelemetry/pom.xml
+++ b/enkan-component-opentelemetry/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>enkan-component-opentelemetry</artifactId>

--- a/enkan-component-thymeleaf/pom.xml
+++ b/enkan-component-thymeleaf/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>enkan-component-thymeleaf</artifactId>

--- a/enkan-component-undertow/pom.xml
+++ b/enkan-component-undertow/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>enkan-component-undertow</artifactId>

--- a/enkan-core/pom.xml
+++ b/enkan-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>enkan-core</artifactId>

--- a/enkan-devel-gradle/pom.xml
+++ b/enkan-devel-gradle/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>enkan-devel-gradle</artifactId>

--- a/enkan-devel/pom.xml
+++ b/enkan-devel/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>enkan-devel</artifactId>

--- a/enkan-repl-client/pom.xml
+++ b/enkan-repl-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>enkan-repl-client</artifactId>

--- a/enkan-repl-server/pom.xml
+++ b/enkan-repl-server/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>enkan-repl-server</artifactId>

--- a/enkan-repl/pom.xml
+++ b/enkan-repl/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>enkan-repl</artifactId>

--- a/enkan-servlet/pom.xml
+++ b/enkan-servlet/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>enkan-servlet</artifactId>

--- a/enkan-system/pom.xml
+++ b/enkan-system/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>enkan-system</artifactId>

--- a/enkan-throttling/pom.xml
+++ b/enkan-throttling/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>enkan-throttling</artifactId>

--- a/enkan-web/pom.xml
+++ b/enkan-web/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>enkan-web</artifactId>

--- a/kotowari-example/pom.xml
+++ b/kotowari-example/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
     <artifactId>kotowari-example</artifactId>
     <packaging>jar</packaging>

--- a/kotowari-graalvm-example/pom.xml
+++ b/kotowari-graalvm-example/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>kotowari-graalvm-example</artifactId>

--- a/kotowari-graalvm/pom.xml
+++ b/kotowari-graalvm/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>kotowari-graalvm</artifactId>

--- a/kotowari-jpa/pom.xml
+++ b/kotowari-jpa/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>kotowari-jpa</artifactId>

--- a/kotowari/pom.xml
+++ b/kotowari/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.15.0</version>
+        <version>0.15.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>kotowari</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>net.unit8.enkan</groupId>
     <artifactId>enkan-parent</artifactId>
-    <version>0.15.0</version>
+    <version>0.15.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>enkan-parent</name>
@@ -23,7 +23,7 @@
             -XX:+EnableDynamicAgentLoading
         </surefire.argLine.common>
 
-        <enkan.version>0.15.0</enkan.version>
+        <enkan.version>0.15.1-SNAPSHOT</enkan.version>
         <maven.version>3.6.3</maven.version>
 
         <!-- Maven Plugin-->

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Perform a full release: merge develop→master, set version, tag, push.
+# Usage: ./scripts/release.sh <release-version> <next-snapshot-version>
+# Example: ./scripts/release.sh 0.15.0 0.15.1-SNAPSHOT
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <release-version> <next-snapshot-version>" >&2
+  echo "Example: $0 0.15.0 0.15.1-SNAPSHOT" >&2
+  exit 1
+fi
+
+RELEASE_VERSION="$1"
+NEXT_VERSION="$2"
+
+# Validate: release version must not contain SNAPSHOT
+if [[ "$RELEASE_VERSION" == *SNAPSHOT* ]]; then
+  echo "ERROR: release version must not be a SNAPSHOT: $RELEASE_VERSION" >&2
+  exit 1
+fi
+
+# Validate: next version must contain SNAPSHOT
+if [[ "$NEXT_VERSION" != *SNAPSHOT* ]]; then
+  echo "ERROR: next version must be a SNAPSHOT: $NEXT_VERSION" >&2
+  exit 1
+fi
+
+echo "=== Step 1: Verify working tree is clean ==="
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "ERROR: working tree has uncommitted changes. Commit or stash them first." >&2
+  exit 1
+fi
+
+echo "=== Step 2: Merge develop → master ==="
+git checkout master
+git pull origin master
+git merge origin/develop --no-edit
+
+echo "=== Step 3: Set release version $RELEASE_VERSION ==="
+./scripts/update-version.sh "$RELEASE_VERSION"
+
+# Verify no SNAPSHOT remains in pom files
+if grep -r "SNAPSHOT" "$ROOT_DIR" --include="pom.xml" -l | grep -v "target/"; then
+  echo "ERROR: SNAPSHOT version still found in pom.xml files after update." >&2
+  exit 1
+fi
+echo "  ✓ No SNAPSHOT versions remain"
+
+echo "=== Step 4: Commit and tag ==="
+git add -A
+git commit -m "release: v${RELEASE_VERSION}"
+git tag "v${RELEASE_VERSION}"
+
+echo "=== Step 5: Push master + tag ==="
+git push origin master --tags
+
+echo "=== Step 6: Bump develop to $NEXT_VERSION ==="
+git checkout develop
+git pull origin develop
+git merge master --no-edit
+
+git checkout -b "feature/next-snapshot-${NEXT_VERSION%-SNAPSHOT}"
+./scripts/update-version.sh "$NEXT_VERSION"
+git add -A
+git commit -m "chore: bump version to ${NEXT_VERSION}"
+git push -u origin "feature/next-snapshot-${NEXT_VERSION%-SNAPSHOT}"
+gh pr create --base develop \
+  --head "feature/next-snapshot-${NEXT_VERSION%-SNAPSHOT}" \
+  --title "chore: bump version to ${NEXT_VERSION}" \
+  --body "Post-release version bump to \`${NEXT_VERSION}\`."
+
+echo ""
+echo "=== Release v${RELEASE_VERSION} complete ==="
+echo "  - Tag v${RELEASE_VERSION} pushed → CI will publish to Maven Central"
+echo "  - PR opened to bump develop to ${NEXT_VERSION}"


### PR DESCRIPTION
Post-release version bump to `0.15.1-SNAPSHOT`.