### PR TITLE
feat: adopt JSpecify nullability annotations across all modules

### DIFF
--- a/enkan-component-HikariCP/pom.xml
+++ b/enkan-component-HikariCP/pom.xml
@@ -21,6 +21,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
             <version>${hikaricp.version}</version>

--- a/enkan-component-HikariCP/src/main/java/enkan/component/hikaricp/HikariCPComponent.java
+++ b/enkan-component-HikariCP/src/main/java/enkan/component/hikaricp/HikariCPComponent.java
@@ -9,6 +9,8 @@ import enkan.component.HealthCheckable;
 import enkan.component.HealthStatus;
 import enkan.exception.MisconfigurationException;
 
+import org.jspecify.annotations.Nullable;
+
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -20,7 +22,7 @@ import java.sql.SQLException;
  */
 public class HikariCPComponent extends DataSourceComponent<HikariCPComponent> implements HealthCheckable {
     private HikariConfig config;
-    private HikariDataSource dataSource;
+    private @Nullable HikariDataSource dataSource;
 
     public HikariCPComponent() {
         config = new HikariConfig();
@@ -62,7 +64,7 @@ public class HikariCPComponent extends DataSourceComponent<HikariCPComponent> im
     }
 
     @Override
-    public DataSource getDataSource() {
+    public @Nullable DataSource getDataSource() {
         return dataSource;
     }
 

--- a/enkan-component-HikariCP/src/main/java/enkan/component/hikaricp/package-info.java
+++ b/enkan-component-HikariCP/src/main/java/enkan/component/hikaricp/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.component.hikaricp;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-doma2/pom.xml
+++ b/enkan-component-doma2/pom.xml
@@ -20,6 +20,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.seasar.doma</groupId>
             <artifactId>doma-core</artifactId>
             <version>${doma.version}</version>

--- a/enkan-component-doma2/src/main/java/enkan/component/doma2/DomaProvider.java
+++ b/enkan-component-doma2/src/main/java/enkan/component/doma2/DomaProvider.java
@@ -13,6 +13,8 @@ import org.seasar.doma.jdbc.dialect.StandardDialect;
 import org.seasar.doma.jdbc.tx.EnkanLocalTransactionDataSource;
 import org.seasar.doma.jdbc.tx.LocalTransactionDataSource;
 
+import org.jspecify.annotations.Nullable;
+
 import javax.sql.DataSource;
 import java.lang.reflect.Constructor;
 import java.util.concurrent.ConcurrentHashMap;
@@ -48,10 +50,10 @@ import static enkan.util.ReflectionUtils.*;
  * @author kawasima
  */
 public class DomaProvider extends SystemComponent<DomaProvider> {
-    private DataSource dataSource;
+    private @Nullable DataSource dataSource;
     private final ConcurrentHashMap<String, Object> daoCache = new ConcurrentHashMap<>();
-    private Config defaultConfig;
-    private Dialect dialect;
+    private @Nullable Config defaultConfig;
+    private @Nullable Dialect dialect;
     private Naming naming = Naming.DEFAULT;
     private boolean useLocalTransaction = true;
     private int maxRows = 0;
@@ -100,6 +102,8 @@ public class DomaProvider extends SystemComponent<DomaProvider> {
                     component.dataSource = new EnkanLocalTransactionDataSource(component.dataSource);
                 }
                 if (component.dialect == null) component.dialect = new StandardDialect();
+                final DataSource cfgDataSource = java.util.Objects.requireNonNull(component.dataSource);
+                final Dialect cfgDialect = java.util.Objects.requireNonNull(component.dialect);
                 component.defaultConfig = new Config() {
                     @Override
                     public Naming getNaming() {
@@ -108,12 +112,12 @@ public class DomaProvider extends SystemComponent<DomaProvider> {
 
                     @Override
                     public DataSource getDataSource() {
-                        return component.dataSource;
+                        return cfgDataSource;
                     }
 
                     @Override
                     public Dialect getDialect() {
-                        return component.dialect;
+                        return cfgDialect;
                     }
 
                     @Override
@@ -152,7 +156,7 @@ public class DomaProvider extends SystemComponent<DomaProvider> {
         };
     }
 
-    public Config getDefaultConfig() {
+    public @Nullable Config getDefaultConfig() {
         return defaultConfig;
     }
 

--- a/enkan-component-doma2/src/main/java/enkan/component/doma2/package-info.java
+++ b/enkan-component-doma2/src/main/java/enkan/component/doma2/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.component.doma2;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-doma2/src/main/java/enkan/middleware/doma2/DomaTransactionMiddleware.java
+++ b/enkan-component-doma2/src/main/java/enkan/middleware/doma2/DomaTransactionMiddleware.java
@@ -16,6 +16,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 import javax.sql.DataSource;
 import jakarta.transaction.Transactional;
+import org.jspecify.annotations.Nullable;
 import java.lang.reflect.Method;
 
 /**
@@ -30,7 +31,7 @@ public class DomaTransactionMiddleware<REQ, RES> implements DecoratorMiddleware<
     @Inject
     private DomaProvider domaProvider;
 
-    private TransactionManager tm;
+    private @Nullable TransactionManager tm;
 
     /**
      * Retrieves the transaction type from the given method.
@@ -38,7 +39,7 @@ public class DomaTransactionMiddleware<REQ, RES> implements DecoratorMiddleware<
      * @param m the method to inspect
      * @return the transaction type, or null if not found
      */
-    private Transactional.TxType getTransactionType(Method m) {
+    private Transactional.@Nullable TxType getTransactionType(Method m) {
         Transactional transactional = m.getDeclaredAnnotation(Transactional.class);
         return transactional != null ? transactional.value() : null;
     }
@@ -46,6 +47,9 @@ public class DomaTransactionMiddleware<REQ, RES> implements DecoratorMiddleware<
     @PostConstruct
     private void init() {
         Config defaultConfig = domaProvider.getDefaultConfig();
+        if (defaultConfig == null) {
+            throw new MisconfigurationException("doma2.TX_MANAGER_NOT_AVAILABLE");
+        }
         DataSource ds = defaultConfig.getDataSource(); // returns LocalTransactionDataSource
         if (ds instanceof EnkanLocalTransactionDataSource ltds) {
             tm = new LocalTransactionManager(ltds.getLocalTransaction(ConfigSupport.defaultJdbcLogger));
@@ -55,10 +59,11 @@ public class DomaTransactionMiddleware<REQ, RES> implements DecoratorMiddleware<
     }
 
     @Override
-    public <NRES, NREQ> RES handle(REQ req, MiddlewareChain<REQ, RES, NRES, NREQ> chain) {
+    public <NRES, NREQ> @Nullable RES handle(REQ req, MiddlewareChain<REQ, RES, NRES, NREQ> chain) {
         if (req instanceof Routable routable) {
             Method m = routable.getControllerMethod();
-            Transactional.TxType type= getTransactionType(m);
+            if (m == null) return chain.next(req);
+            Transactional.TxType type = getTransactionType(m);
 
             if (type != null) {
                 if (tm == null) {

--- a/enkan-component-doma2/src/main/java/enkan/middleware/doma2/package-info.java
+++ b/enkan-component-doma2/src/main/java/enkan/middleware/doma2/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.middleware.doma2;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-eclipselink/pom.xml
+++ b/enkan-component-eclipselink/pom.xml
@@ -20,6 +20,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.unit8.enkan</groupId>
             <artifactId>enkan-component-jpa</artifactId>
             <version>${enkan.version}</version>
@@ -82,5 +86,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 </project>

--- a/enkan-component-eclipselink/src/main/java/enkan/component/eclipselink/package-info.java
+++ b/enkan-component-eclipselink/src/main/java/enkan/component/eclipselink/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.component.eclipselink;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-flyway/pom.xml
+++ b/enkan-component-flyway/pom.xml
@@ -20,6 +20,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
             <version>${flyway.version}</version>

--- a/enkan-component-flyway/src/main/java/enkan/component/flyway/FlywayMigration.java
+++ b/enkan-component-flyway/src/main/java/enkan/component/flyway/FlywayMigration.java
@@ -9,12 +9,15 @@ import org.flywaydb.core.api.configuration.FluentConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.jspecify.annotations.Nullable;
+
 import javax.sql.DataSource;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -25,14 +28,14 @@ import java.util.Optional;
 public class FlywayMigration extends SystemComponent<FlywayMigration> {
     private static final Logger LOG = LoggerFactory.getLogger(FlywayMigration.class);
 
-    private String[] locations;
+    private String @Nullable [] locations;
     private boolean cleanBeforeMigration = false;
     /** The table name for Flyway's schema history. Defaults to "schema_version" (Flyway default: "flyway_schema_history"). */
     private String table = "schema_version";
-    private Flyway flyway;
+    private @Nullable Flyway flyway;
 
     private boolean isMigrationAvailable() {
-        return Arrays.stream(flyway.getConfiguration().getLocations())
+        return Arrays.stream(Objects.requireNonNull(flyway).getConfiguration().getLocations())
                 .anyMatch(l -> {
                     if (CoreLocationPrefix.isClassPath(l)) {
                         return Thread.currentThread().getContextClassLoader().getResource(l.getRootPath()) != null;
@@ -50,7 +53,8 @@ public class FlywayMigration extends SystemComponent<FlywayMigration> {
             @Override
             public void start(FlywayMigration component) {
                 DataSourceComponent<?> dataSourceComponent = getDependency(DataSourceComponent.class);
-                DataSource dataSource = dataSourceComponent.getDataSource();
+                DataSource dataSource = Objects.requireNonNull(dataSourceComponent.getDataSource(),
+                        "DataSourceComponent has not been started");
                 FluentConfiguration configuration = Flyway.configure(Thread.currentThread().getContextClassLoader())
                         .table(table)
                         .baselineOnMigrate(true)

--- a/enkan-component-flyway/src/main/java/enkan/component/flyway/package-info.java
+++ b/enkan-component-flyway/src/main/java/enkan/component/flyway/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.component.flyway;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-freemarker/pom.xml
+++ b/enkan-component-freemarker/pom.xml
@@ -20,6 +20,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
             <version>${freemarker.version}</version>

--- a/enkan-component-freemarker/src/main/java/enkan/component/freemarker/FreemarkerTemplateEngine.java
+++ b/enkan-component-freemarker/src/main/java/enkan/component/freemarker/FreemarkerTemplateEngine.java
@@ -15,6 +15,7 @@ import kotowari.component.TemplateEngine;
 import kotowari.data.TemplatedHttpResponse;
 import kotowari.data.Validatable;
 import kotowari.io.LazyRenderInputStream;
+import org.jspecify.annotations.Nullable;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -24,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.function.Function;
 
 
@@ -33,12 +35,12 @@ import java.util.function.Function;
  * @author kawasima
  */
 public class FreemarkerTemplateEngine extends TemplateEngine<FreemarkerTemplateEngine> {
-    private Configuration config;
+    private @Nullable Configuration config;
     private String prefix = "templates";
     private String suffix = ".ftl";
-    private ClassLoader classLoader;
+    private @Nullable ClassLoader classLoader;
     private Charset encoding = StandardCharsets.UTF_8;
-    private TemplateLoader templateLoader;
+    private @Nullable TemplateLoader templateLoader;
 
     private OutputFormat outputFormat = HTMLOutputFormat.INSTANCE;
 
@@ -50,7 +52,8 @@ public class FreemarkerTemplateEngine extends TemplateEngine<FreemarkerTemplateE
         TemplatedHttpResponse response = TemplatedHttpResponse.create(name, keyOrVals);
         response.setBody(new LazyRenderInputStream(() -> {
             try {
-                Template template = config.getTemplate(name + suffix, encoding.name());
+                Template template = Objects.requireNonNull(config, "FreemarkerTemplateEngine has not been started")
+                        .getTemplate(name + suffix, encoding.name());
                 StringWriter writer = new StringWriter();
                 template.process(response.getContext(), writer);
                 return new ByteArrayInputStream(writer.toString().getBytes(encoding));

--- a/enkan-component-freemarker/src/main/java/enkan/component/freemarker/ValidatableFormAdapter.java
+++ b/enkan-component-freemarker/src/main/java/enkan/component/freemarker/ValidatableFormAdapter.java
@@ -6,6 +6,7 @@ import freemarker.template.TemplateMethodModelEx;
 import freemarker.template.TemplateModel;
 import freemarker.template.TemplateModelException;
 import kotowari.data.Validatable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Form object model.
@@ -31,7 +32,7 @@ public class ValidatableFormAdapter extends BeanModel {
         };
     }
 
-    public TemplateModel get(String key) throws TemplateModelException {
+    public @Nullable TemplateModel get(String key) throws TemplateModelException {
         TemplateModel model = super.get(key);
         if (model == null) {
             return switch (key) {

--- a/enkan-component-freemarker/src/main/java/enkan/component/freemarker/package-info.java
+++ b/enkan-component-freemarker/src/main/java/enkan/component/freemarker/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.component.freemarker;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-jackson/pom.xml
+++ b/enkan-component-jackson/pom.xml
@@ -16,6 +16,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>

--- a/enkan-component-jackson/src/main/java/enkan/component/jackson/JacksonBeansConverter.java
+++ b/enkan-component-jackson/src/main/java/enkan/component/jackson/JacksonBeansConverter.java
@@ -4,24 +4,30 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import enkan.component.AbstractBeansConverter;
 import enkan.component.ComponentLifecycle;
 import enkan.exception.MisconfigurationException;
+
+import org.jspecify.annotations.Nullable;
+
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
+import java.util.Objects;
+
 /**
  * @author kawasima
  */
 public class JacksonBeansConverter extends AbstractBeansConverter<JacksonBeansConverter> {
-    private ObjectMapper mapper;
-    private ObjectMapper nonNullMapper;
+    private @Nullable ObjectMapper mapper;
+    private @Nullable ObjectMapper nonNullMapper;
 
     @Override
     public void copy(Object source, Object destination, CopyOption copyOption) {
+        ObjectMapper mapper = Objects.requireNonNull(this.mapper, "JacksonBeansConverter has not been started");
         try {
             switch (copyOption) {
                 case REPLACE_NON_NULL -> {
-                    byte[] buf = nonNullMapper.writeValueAsBytes(source);
+                    byte[] buf = Objects.requireNonNull(nonNullMapper).writeValueAsBytes(source);
                     mapper.readerForUpdating(destination).readValue(buf);
                 }
                 case REPLACE_ALL -> {
@@ -46,7 +52,8 @@ public class JacksonBeansConverter extends AbstractBeansConverter<JacksonBeansCo
                 || destinationClass.equals(String.class)) {
             throw new IllegalArgumentException("destinationClass cannot be mapped to JSON object class");
         }
-        return mapper.convertValue(source, destinationClass);
+        return Objects.requireNonNull(mapper, "JacksonBeansConverter has not been started")
+                .convertValue(source, destinationClass);
     }
 
     @Override

--- a/enkan-component-jackson/src/main/java/enkan/component/jackson/package-info.java
+++ b/enkan-component-jackson/src/main/java/enkan/component/jackson/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.component.jackson;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-jetty/pom.xml
+++ b/enkan-component-jetty/pom.xml
@@ -19,6 +19,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.unit8.enkan</groupId>
             <artifactId>enkan-system</artifactId>
             <version>${enkan.version}</version>

--- a/enkan-component-jetty/src/main/java/enkan/component/jetty/JettyAdapter.java
+++ b/enkan-component-jetty/src/main/java/enkan/component/jetty/JettyAdapter.java
@@ -52,6 +52,10 @@ public class JettyAdapter {
             HttpRequest request = ServletUtils.buildRequest(servletRequest, application::createRequest);
             try {
                 HttpResponse response = application.handle(request);
+                if (response == null) {
+                    servletResponse.sendError(HttpServletResponse.SC_NOT_FOUND);
+                    return;
+                }
                 ServletUtils.updateServletResponse(servletResponse, response);
             } catch (Exception e) {
                 LOG.error("Unhandled exception", e);
@@ -86,7 +90,8 @@ public class JettyAdapter {
         }
         context.setTrustStorePassword(options.getString("truststorePassword"));
 
-        String clientAuth = options.getString("clientAuth", "none");
+        String clientAuthOpt = options.getString("clientAuth", "none");
+        String clientAuth = clientAuthOpt != null ? clientAuthOpt : "none";
         switch (clientAuth) {
             case "need" -> context.setNeedClientAuth(true);
             case "want" -> context.setWantClientAuth(true);

--- a/enkan-component-jetty/src/main/java/enkan/component/jetty/JettyComponent.java
+++ b/enkan-component-jetty/src/main/java/enkan/component/jetty/JettyComponent.java
@@ -17,6 +17,7 @@ import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.jspecify.annotations.Nullable;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -28,12 +29,12 @@ import java.util.function.BiFunction;
 public class JettyComponent extends WebServerComponent<JettyComponent> implements HealthCheckable {
     private static final Logger LOG = LoggerFactory.getLogger(JettyComponent.class);
 
-    private Server server;
-    private BiFunction<Server, OptionMap, Connector> serverConnectorFactory;
+    private @Nullable Server server;
+    private @Nullable BiFunction<Server, OptionMap, Connector> serverConnectorFactory;
     private boolean virtualThreads = true;
     private volatile boolean stopping = false;
     private final Map<String, WebSocketHandler> wsHandlers = new LinkedHashMap<>();
-    private String digestAlgorithm = null;
+    private @Nullable String digestAlgorithm = null;
 
     @Override
     protected ComponentLifecycle<JettyComponent> lifecycle() {

--- a/enkan-component-jetty/src/main/java/enkan/component/jetty/digest/DigestFilter.java
+++ b/enkan-component-jetty/src/main/java/enkan/component/jetty/digest/DigestFilter.java
@@ -3,6 +3,7 @@ package enkan.component.jetty.digest;
 import enkan.web.http.fields.digest.DigestFields;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
+import org.jspecify.annotations.Nullable;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpServletResponseWrapper;
 
@@ -49,7 +50,7 @@ public class DigestFilter implements Filter {
      */
     public static final String PARAM_COMPRESSED = "compressed";
 
-    private String defaultAlgorithm;
+    private @Nullable String defaultAlgorithm;
     private boolean compressed;
 
     @Override
@@ -116,8 +117,8 @@ public class DigestFilter implements Filter {
     static final class BufferingResponseWrapper extends HttpServletResponseWrapper {
 
         private final ByteArrayOutputStream buffer = new ByteArrayOutputStream(4096);
-        private ServletOutputStream outputStream;
-        private PrintWriter writer;
+        private @Nullable ServletOutputStream outputStream;
+        private @Nullable PrintWriter writer;
 
         BufferingResponseWrapper(HttpServletResponse response) {
             super(response);

--- a/enkan-component-jetty/src/main/java/enkan/component/jetty/digest/package-info.java
+++ b/enkan-component-jetty/src/main/java/enkan/component/jetty/digest/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.component.jetty.digest;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-jetty/src/main/java/enkan/component/jetty/package-info.java
+++ b/enkan-component-jetty/src/main/java/enkan/component/jetty/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.component.jetty;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-jetty/src/main/java/enkan/component/jetty/websocket/JettyWebSocketEndpoint.java
+++ b/enkan-component-jetty/src/main/java/enkan/component/jetty/websocket/JettyWebSocketEndpoint.java
@@ -3,6 +3,7 @@ package enkan.component.jetty.websocket;
 import enkan.web.websocket.WebSocketHandler;
 import org.eclipse.jetty.websocket.api.Callback;
 import org.eclipse.jetty.websocket.api.Session;
+import org.jspecify.annotations.Nullable;
 
 import java.nio.ByteBuffer;
 
@@ -20,7 +21,7 @@ class JettyWebSocketEndpoint extends Session.Listener.AbstractAutoDemanding {
 
     private final String id;
     private final WebSocketHandler handler;
-    private volatile JettyWebSocketSession session;
+    private volatile @Nullable JettyWebSocketSession session;
 
     JettyWebSocketEndpoint(String id, WebSocketHandler handler) {
         this.id = id;
@@ -40,40 +41,52 @@ class JettyWebSocketEndpoint extends Session.Listener.AbstractAutoDemanding {
 
     @Override
     public void onWebSocketText(String message) {
+        JettyWebSocketSession s = session;
+        if (s == null) return;
         try {
-            handler.onMessage(session, message);
+            handler.onMessage(s, message);
         } catch (Throwable cause) {
-            handler.onError(session, cause);
+            handler.onError(s, cause);
         }
     }
 
     @Override
     public void onWebSocketBinary(ByteBuffer payload, Callback callback) {
+        JettyWebSocketSession s = session;
+        if (s == null) {
+            callback.succeed();
+            return;
+        }
         // Copy the payload before completing the callback — Jetty may recycle
         // the underlying buffer once the callback completes.
         ByteBuffer copy = ByteBuffer.allocate(payload.remaining());
         copy.put(payload);
         copy.flip();
         try {
-            handler.onBinary(session, copy);
+            handler.onBinary(s, copy);
             callback.succeed();
         } catch (Throwable cause) {
-            handler.onError(session, cause);
+            handler.onError(s, cause);
             callback.fail(cause);
         }
     }
 
     @Override
     public void onWebSocketClose(int statusCode, String reason) {
+        JettyWebSocketSession s = session;
+        if (s == null) return;
         try {
-            handler.onClose(session, statusCode, reason);
+            handler.onClose(s, statusCode, reason);
         } catch (Throwable cause) {
-            handler.onError(session, cause);
+            handler.onError(s, cause);
         }
     }
 
     @Override
     public void onWebSocketError(Throwable cause) {
-        handler.onError(session, cause);
+        JettyWebSocketSession s = session;
+        if (s != null) {
+            handler.onError(s, cause);
+        }
     }
 }

--- a/enkan-component-jetty/src/main/java/enkan/component/jetty/websocket/package-info.java
+++ b/enkan-component-jetty/src/main/java/enkan/component/jetty/websocket/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.component.jetty.websocket;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-jooq/pom.xml
+++ b/enkan-component-jooq/pom.xml
@@ -20,6 +20,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>jooq</artifactId>
             <version>${jooq.version}</version>

--- a/enkan-component-jooq/src/main/java/enkan/component/jooq/JooqProvider.java
+++ b/enkan-component-jooq/src/main/java/enkan/component/jooq/JooqProvider.java
@@ -7,11 +7,12 @@ import enkan.exception.MisconfigurationException;
 import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
+import org.jspecify.annotations.Nullable;
 
 import javax.sql.DataSource;
 
 public class JooqProvider extends SystemComponent<JooqProvider> {
-    private DSLContext dsl;
+    private @Nullable DSLContext dsl;
     private SQLDialect dialect = SQLDialect.DEFAULT;
 
     public DSLContext getDSLContext() {

--- a/enkan-component-jooq/src/main/java/enkan/component/jooq/package-info.java
+++ b/enkan-component-jooq/src/main/java/enkan/component/jooq/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.component.jooq;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-jooq/src/main/java/enkan/middleware/jooq/JooqDslContextMiddleware.java
+++ b/enkan-component-jooq/src/main/java/enkan/middleware/jooq/JooqDslContextMiddleware.java
@@ -9,6 +9,7 @@ import enkan.data.Extendable;
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 import org.jooq.DSLContext;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Provides a non-transactional jOOQ {@link DSLContext} to downstream handlers.
@@ -29,7 +30,7 @@ public class JooqDslContextMiddleware<REQ, RES> implements DecoratorMiddleware<R
     @Inject
     private JooqProvider jooqProvider;
 
-    private DSLContext dsl;
+    private @Nullable DSLContext dsl;
 
     @PostConstruct
     void init() {
@@ -37,7 +38,7 @@ public class JooqDslContextMiddleware<REQ, RES> implements DecoratorMiddleware<R
     }
 
     @Override
-    public <NNREQ, NNRES> RES handle(REQ req, MiddlewareChain<REQ, RES, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable RES handle(REQ req, MiddlewareChain<REQ, RES, NNREQ, NNRES> chain) {
         if (req instanceof Extendable e) {
             e.setExtension("jooqDslContext", dsl);
         }

--- a/enkan-component-jooq/src/main/java/enkan/middleware/jooq/JooqTransactionMiddleware.java
+++ b/enkan-component-jooq/src/main/java/enkan/middleware/jooq/JooqTransactionMiddleware.java
@@ -12,8 +12,10 @@ import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import org.jooq.DSLContext;
 import org.jooq.impl.DSL;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Method;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -44,25 +46,25 @@ public class JooqTransactionMiddleware<REQ, RES> implements DecoratorMiddleware<
     @Inject
     private JooqProvider jooqProvider;
 
-    private DSLContext dsl;
+    private @Nullable DSLContext dsl;
 
     @PostConstruct
     void init() {
         dsl = jooqProvider.getDSLContext();
     }
 
-    private Transactional.TxType getTransactionType(Class<?> cls) {
+    private Transactional.@Nullable TxType getTransactionType(Class<?> cls) {
         Transactional tx = cls.getDeclaredAnnotation(Transactional.class);
         return tx != null ? tx.value() : null;
     }
 
-    private Transactional.TxType getTransactionType(Method m) {
+    private Transactional.@Nullable TxType getTransactionType(Method m) {
         Transactional tx = m.getDeclaredAnnotation(Transactional.class);
         return tx != null ? tx.value() : null;
     }
 
     @Override
-    public <NNREQ, NNRES> RES handle(REQ req, MiddlewareChain<REQ, RES, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable RES handle(REQ req, MiddlewareChain<REQ, RES, NNREQ, NNRES> chain) {
         if (req instanceof Routable routable) {
             Transactional.TxType type = getTransactionType(routable.getControllerClass());
             Method m = routable.getControllerMethod();
@@ -71,7 +73,7 @@ public class JooqTransactionMiddleware<REQ, RES> implements DecoratorMiddleware<
             }
             if (type != null) {
                 return switch (type) {
-                    case REQUIRED -> dsl.transactionResult(ctx -> {
+                    case REQUIRED -> Objects.requireNonNull(dsl).transactionResult(ctx -> {
                         if (req instanceof Extendable e) e.setExtension("jooqDslContext", DSL.using(ctx));
                         return chain.next(req);
                     });

--- a/enkan-component-jooq/src/main/java/enkan/middleware/jooq/package-info.java
+++ b/enkan-component-jooq/src/main/java/enkan/middleware/jooq/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.middleware.jooq;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-jpa/pom.xml
+++ b/enkan-component-jpa/pom.xml
@@ -16,6 +16,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
         </dependency>
@@ -39,5 +43,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 </project>

--- a/enkan-component-jpa/src/main/java/enkan/component/jpa/EntityManagerProvider.java
+++ b/enkan-component-jpa/src/main/java/enkan/component/jpa/EntityManagerProvider.java
@@ -6,18 +6,20 @@ import enkan.exception.MisconfigurationException;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
+import org.jspecify.annotations.Nullable;
+
 import javax.sql.DataSource;
 import java.util.HashMap;
 import java.util.Map;
 
 public abstract class EntityManagerProvider<T extends SystemComponent<T>> extends SystemComponent<T> {
-    private String name;
+    private @Nullable String name;
 
-    private DataSourceComponent<?> dataSourceComponent;
+    private @Nullable DataSourceComponent<?> dataSourceComponent;
 
     private Map<String, Object> jpaProperties = new HashMap<>();
 
-    private EntityManagerFactory entityManagerFactory;
+    private @Nullable EntityManagerFactory entityManagerFactory;
 
     public EntityManager createEntityManager() {
         if (entityManagerFactory == null) {
@@ -34,7 +36,7 @@ public abstract class EntityManagerProvider<T extends SystemComponent<T>> extend
         this.jpaProperties = jpaProperties;
     }
 
-    protected String getName() {
+    protected @Nullable String getName() {
         return this.name;
     }
 
@@ -46,11 +48,11 @@ public abstract class EntityManagerProvider<T extends SystemComponent<T>> extend
         this.entityManagerFactory = entityManagerFactory;
     }
 
-    public EntityManagerFactory getEntityManagerFactory() {
+    public @Nullable EntityManagerFactory getEntityManagerFactory() {
         return entityManagerFactory;
     }
 
-    protected DataSource getDataSource() {
+    protected @Nullable DataSource getDataSource() {
         if (dataSourceComponent == null) {
             throw new MisconfigurationException("core.COMPONENT_NOT_FOUND", "DataSourceComponent", getClass().getSimpleName());
         }

--- a/enkan-component-jpa/src/main/java/enkan/component/jpa/package-info.java
+++ b/enkan-component-jpa/src/main/java/enkan/component/jpa/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.component.jpa;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-jpa/src/main/java/enkan/data/jpa/EntityManageable.java
+++ b/enkan-component-jpa/src/main/java/enkan/data/jpa/EntityManageable.java
@@ -3,13 +3,14 @@ package enkan.data.jpa;
 import enkan.data.Extendable;
 
 import jakarta.persistence.EntityManager;
+import org.jspecify.annotations.Nullable;
 
 public interface EntityManageable extends Extendable {
     default void setEntityManager(EntityManager entityManager) {
         setExtension("entityManager", entityManager);
     }
 
-    default EntityManager getEntityManager() {
+    default @Nullable EntityManager getEntityManager() {
         return getExtension("entityManager");
     }
 }

--- a/enkan-component-jpa/src/main/java/enkan/data/jpa/package-info.java
+++ b/enkan-component-jpa/src/main/java/enkan/data/jpa/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.data.jpa;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-jpa/src/main/java/enkan/middleware/jpa/EntityManagerMiddleware.java
+++ b/enkan-component-jpa/src/main/java/enkan/middleware/jpa/EntityManagerMiddleware.java
@@ -9,6 +9,7 @@ import enkan.util.MixinUtils;
 
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
+import org.jspecify.annotations.Nullable;
 
 @Middleware(name = "entityManager", mixins = EntityManageable.class)
 public class EntityManagerMiddleware<REQ, RES> implements DecoratorMiddleware<REQ, RES> {
@@ -16,7 +17,7 @@ public class EntityManagerMiddleware<REQ, RES> implements DecoratorMiddleware<RE
     private EntityManagerProvider<?> entityManagerProvider;
 
     @Override
-    public <NNREQ, NNRES> RES handle(REQ req, MiddlewareChain<REQ, RES, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable RES handle(REQ req, MiddlewareChain<REQ, RES, NNREQ, NNRES> chain) {
         EntityManager em = entityManagerProvider.createEntityManager();
         try (em) {
             req = MixinUtils.mixin(req, EntityManageable.class);

--- a/enkan-component-jpa/src/main/java/enkan/middleware/jpa/NonJtaTransactionMiddleware.java
+++ b/enkan-component-jpa/src/main/java/enkan/middleware/jpa/NonJtaTransactionMiddleware.java
@@ -9,23 +9,24 @@ import enkan.exception.MisconfigurationException;
 
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
+import org.jspecify.annotations.Nullable;
 import java.lang.reflect.Method;
 import java.util.Optional;
 
 @Middleware(name = "nonJtaTransaction", dependencies = {"entityManager", "routing"})
 public class NonJtaTransactionMiddleware<REQ, RES> implements DecoratorMiddleware<REQ, RES> {
-    private Transactional.TxType getTransactionType(Class<?> cls) {
+    private Transactional.@Nullable TxType getTransactionType(Class<?> cls) {
         Transactional transactional = cls.getDeclaredAnnotation(Transactional.class);
         return transactional != null ? transactional.value() : null;
     }
 
-    private Transactional.TxType getTransactionType(Method m) {
+    private Transactional.@Nullable TxType getTransactionType(Method m) {
         Transactional transactional = m.getDeclaredAnnotation(Transactional.class);
         return transactional != null ? transactional.value() : null;
     }
 
     @Override
-    public <NNREQ, NNRES> RES handle(REQ req, MiddlewareChain<REQ, RES, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable RES handle(REQ req, MiddlewareChain<REQ, RES, NNREQ, NNRES> chain) {
         EntityManager em = Optional.ofNullable(req)
                 .filter(EntityManageable.class::isInstance)
                 .map(EntityManageable.class::cast)
@@ -42,7 +43,7 @@ public class NonJtaTransactionMiddleware<REQ, RES> implements DecoratorMiddlewar
                     case REQUIRED, REQUIRES_NEW -> {
                         em.getTransaction().begin();
                         try {
-                            RES ret = chain.next(req);
+                            @Nullable RES ret = chain.next(req);
                             if (em.getTransaction().getRollbackOnly()) {
                                 em.getTransaction().rollback();
                             } else {

--- a/enkan-component-jpa/src/main/java/enkan/middleware/jpa/package-info.java
+++ b/enkan-component-jpa/src/main/java/enkan/middleware/jpa/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.middleware.jpa;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-jpa/src/main/java/enkan/util/jpa/package-info.java
+++ b/enkan-component-jpa/src/main/java/enkan/util/jpa/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.util.jpa;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-metrics/pom.xml
+++ b/enkan-component-metrics/pom.xml
@@ -20,6 +20,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
             <version>${metrics.version}</version>

--- a/enkan-component-metrics/src/main/java/enkan/component/metrics/MetricsComponent.java
+++ b/enkan-component-metrics/src/main/java/enkan/component/metrics/MetricsComponent.java
@@ -8,7 +8,10 @@ import com.codahale.metrics.jmx.JmxReporter;
 import enkan.component.ComponentLifecycle;
 import enkan.component.SystemComponent;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Collections;
+import java.util.Objects;
 import java.util.SortedSet;
 
 import static com.codahale.metrics.MetricRegistry.name;
@@ -24,12 +27,12 @@ import static com.codahale.metrics.MetricRegistry.name;
 public class MetricsComponent extends SystemComponent<MetricsComponent> {
     private String metricName = "enkan";
 
-    private Meter timeoutsMeter;
-    private Meter errorsMeter;
-    private Counter activeRequests;
-    private Timer requestTimer;
+    private @Nullable Meter timeoutsMeter;
+    private @Nullable Meter errorsMeter;
+    private @Nullable Counter activeRequests;
+    private @Nullable Timer requestTimer;
 
-    private JmxReporter reporter;
+    private @Nullable JmxReporter reporter;
     private final MetricRegistry metricRegistry;
 
     public MetricsComponent() {
@@ -51,7 +54,7 @@ public class MetricsComponent extends SystemComponent<MetricsComponent> {
 
             @Override
             public void stop(MetricsComponent component) {
-                component.reporter.stop();
+                Objects.requireNonNull(component.reporter).stop();
                 component.reporter = null;
 
                 SortedSet<String> names = Collections.unmodifiableSortedSet(metricRegistry.getNames());
@@ -65,19 +68,19 @@ public class MetricsComponent extends SystemComponent<MetricsComponent> {
         };
     }
 
-    public Meter getTimeouts() {
+    public @Nullable Meter getTimeouts() {
         return timeoutsMeter;
     }
 
-    public Timer getRequestTimer() {
+    public @Nullable Timer getRequestTimer() {
         return requestTimer;
     }
 
-    public Meter getErrors() {
+    public @Nullable Meter getErrors() {
         return errorsMeter;
     }
 
-    public Counter getActiveRequests() {
+    public @Nullable Counter getActiveRequests() {
         return activeRequests;
     }
 

--- a/enkan-component-metrics/src/main/java/enkan/component/metrics/package-info.java
+++ b/enkan-component-metrics/src/main/java/enkan/component/metrics/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.component.metrics;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-metrics/src/main/java/enkan/middleware/metrics/MetricsMiddleware.java
+++ b/enkan-component-metrics/src/main/java/enkan/middleware/metrics/MetricsMiddleware.java
@@ -1,11 +1,14 @@
 package enkan.middleware.metrics;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Timer;
 import enkan.DecoratorMiddleware;
 import enkan.MiddlewareChain;
 import enkan.component.metrics.MetricsComponent;
+import org.jspecify.annotations.Nullable;
 
 import jakarta.inject.Inject;
+import java.util.Objects;
 
 /**
  * @deprecated Use {@code enkan.middleware.micrometer.MicrometerMiddleware} instead.
@@ -19,17 +22,20 @@ public class MetricsMiddleware<REQ, RES> implements DecoratorMiddleware<REQ, RES
     private MetricsComponent metrics;
 
     @Override
-    public <NNREQ, NNRES> RES handle(REQ req, MiddlewareChain<REQ, RES, NNREQ, NNRES> chain) {
-        Timer.Context context = metrics.getRequestTimer().time();
-        metrics.getActiveRequests().inc();
+    public <NNREQ, NNRES> @Nullable RES handle(REQ req, MiddlewareChain<REQ, RES, NNREQ, NNRES> chain) {
+        Timer.Context context = Objects.requireNonNull(metrics.getRequestTimer(),
+                "MetricsComponent has not been started").time();
+        Counter activeRequests = Objects.requireNonNull(metrics.getActiveRequests(),
+                "MetricsComponent has not been started");
+        activeRequests.inc();
 
         try {
             return chain.next(req);
         } catch (Exception ex) {
-            metrics.getErrors().mark();
+            Objects.requireNonNull(metrics.getErrors()).mark();
             throw ex;
         } finally {
-            metrics.getActiveRequests().dec();
+            activeRequests.dec();
             context.stop();
         }
     }

--- a/enkan-component-metrics/src/main/java/enkan/middleware/metrics/package-info.java
+++ b/enkan-component-metrics/src/main/java/enkan/middleware/metrics/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.middleware.metrics;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-metrics/src/main/java/enkan/system/command/MetricsCommand.java
+++ b/enkan-component-metrics/src/main/java/enkan/system/command/MetricsCommand.java
@@ -9,8 +9,10 @@ import enkan.system.EnkanSystem;
 import enkan.system.ReplResponse;
 import enkan.system.SystemCommand;
 import enkan.system.Transport;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -96,8 +98,8 @@ public class MetricsCommand implements SystemCommand {
     }
 
     @Override
-    public boolean execute(EnkanSystem system, Transport transport, String... args) {
-        Optional<MetricsComponent> found = findMetrics(system);
+    public boolean execute(@Nullable EnkanSystem system, Transport transport, String... args) {
+        Optional<MetricsComponent> found = findMetrics(Objects.requireNonNull(system));
         if (found.isEmpty()) {
             transport.send(ReplResponse.withOut("MetricsComponent is not registered in the system."));
             transport.sendOut("", ReplResponse.ResponseStatus.DONE);
@@ -112,9 +114,9 @@ public class MetricsCommand implements SystemCommand {
         transport.send(ReplResponse.withOut("-- Active Requests ----------------------------------"));
         printCounter(transport, metrics.getActiveRequests());
         transport.send(ReplResponse.withOut("-- Errors ------------------------------------"));
-        printMeter(transport, metrics.getErrors());
+        printMeter(transport, Objects.requireNonNull(metrics.getErrors()));
         transport.send(ReplResponse.withOut("-- Request Timer -----------------------------"));
-        printTimer(transport, metrics.getRequestTimer());
+        printTimer(transport, Objects.requireNonNull(metrics.getRequestTimer()));
         transport.sendOut("", ReplResponse.ResponseStatus.DONE);
         return true;
     }

--- a/enkan-component-metrics/src/main/java/enkan/system/command/package-info.java
+++ b/enkan-component-metrics/src/main/java/enkan/system/command/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.system.command;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-micrometer/pom.xml
+++ b/enkan-component-micrometer/pom.xml
@@ -16,6 +16,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
             <version>${micrometer.version}</version>

--- a/enkan-component-micrometer/src/main/java/enkan/component/micrometer/package-info.java
+++ b/enkan-component-micrometer/src/main/java/enkan/component/micrometer/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.component.micrometer;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-micrometer/src/main/java/enkan/middleware/micrometer/MicrometerMiddleware.java
+++ b/enkan-component-micrometer/src/main/java/enkan/middleware/micrometer/MicrometerMiddleware.java
@@ -5,6 +5,7 @@ import enkan.MiddlewareChain;
 import enkan.component.micrometer.MicrometerComponent;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
+import org.jspecify.annotations.Nullable;
 
 import jakarta.inject.Inject;
 import java.util.Objects;
@@ -23,7 +24,7 @@ public class MicrometerMiddleware<REQ, RES> implements DecoratorMiddleware<REQ, 
     private MicrometerComponent micrometer;
 
     @Override
-    public <NNREQ, NNRES> RES handle(REQ req, MiddlewareChain<REQ, RES, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable RES handle(REQ req, MiddlewareChain<REQ, RES, NNREQ, NNRES> chain) {
         Timer requestTimer = Objects.requireNonNull(micrometer.getRequestTimer(),
                 "MicrometerComponent is not started");
         Counter errorCounter = Objects.requireNonNull(micrometer.getErrorCounter(),

--- a/enkan-component-micrometer/src/main/java/enkan/middleware/micrometer/package-info.java
+++ b/enkan-component-micrometer/src/main/java/enkan/middleware/micrometer/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.middleware.micrometer;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-micrometer/src/main/java/enkan/system/command/MicrometerCommand.java
+++ b/enkan-component-micrometer/src/main/java/enkan/system/command/MicrometerCommand.java
@@ -8,8 +8,10 @@ import enkan.system.Transport;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 import io.micrometer.core.instrument.distribution.ValueAtPercentile;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -57,8 +59,8 @@ public class MicrometerCommand implements SystemCommand {
     }
 
     @Override
-    public boolean execute(EnkanSystem system, Transport transport, String... args) {
-        Optional<MicrometerComponent> found = findMicrometer(system);
+    public boolean execute(@Nullable EnkanSystem system, Transport transport, String... args) {
+        Optional<MicrometerComponent> found = findMicrometer(Objects.requireNonNull(system));
         if (found.isEmpty()) {
             transport.send(ReplResponse.withOut("MicrometerComponent is not registered in the system."));
             transport.sendOut("", ReplResponse.ResponseStatus.DONE);

--- a/enkan-component-micrometer/src/main/java/enkan/system/command/package-info.java
+++ b/enkan-component-micrometer/src/main/java/enkan/system/command/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.system.command;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-opentelemetry/pom.xml
+++ b/enkan-component-opentelemetry/pom.xml
@@ -20,6 +20,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
             <version>${opentelemetry.version}</version>

--- a/enkan-component-opentelemetry/src/main/java/enkan/component/opentelemetry/OpenTelemetryComponent.java
+++ b/enkan-component-opentelemetry/src/main/java/enkan/component/opentelemetry/OpenTelemetryComponent.java
@@ -4,6 +4,7 @@ import enkan.component.ComponentLifecycle;
 import enkan.component.SystemComponent;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
+import org.jspecify.annotations.Nullable;
 
 /**
  * System component that wraps an OpenTelemetry instance and provides tracer access.
@@ -20,7 +21,7 @@ public class OpenTelemetryComponent extends SystemComponent<OpenTelemetryCompone
 
     private OpenTelemetry openTelemetry;
     private String instrumentationName = DEFAULT_INSTRUMENTATION_NAME;
-    private Tracer tracer;
+    private @Nullable Tracer tracer;
 
     /**
      * Creates a component with the noop OpenTelemetry instance.
@@ -59,7 +60,7 @@ public class OpenTelemetryComponent extends SystemComponent<OpenTelemetryCompone
         return openTelemetry;
     }
 
-    public Tracer getTracer() {
+    public @Nullable Tracer getTracer() {
         return tracer;
     }
 

--- a/enkan-component-opentelemetry/src/main/java/enkan/component/opentelemetry/package-info.java
+++ b/enkan-component-opentelemetry/src/main/java/enkan/component/opentelemetry/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.component.opentelemetry;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-opentelemetry/src/main/java/enkan/middleware/opentelemetry/HttpRequestTextMapGetter.java
+++ b/enkan-component-opentelemetry/src/main/java/enkan/middleware/opentelemetry/HttpRequestTextMapGetter.java
@@ -2,6 +2,7 @@ package enkan.middleware.opentelemetry;
 
 import enkan.web.data.HttpRequest;
 import io.opentelemetry.context.propagation.TextMapGetter;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collections;
 
@@ -23,7 +24,7 @@ enum HttpRequestTextMapGetter implements TextMapGetter<HttpRequest> {
     }
 
     @Override
-    public String get(HttpRequest request, String key) {
+    public @Nullable String get(@Nullable HttpRequest request, @Nullable String key) {
         if (request == null || request.getHeaders() == null || key == null) {
             return null;
         }

--- a/enkan-component-opentelemetry/src/main/java/enkan/middleware/opentelemetry/TracingMiddleware.java
+++ b/enkan-component-opentelemetry/src/main/java/enkan/middleware/opentelemetry/TracingMiddleware.java
@@ -14,8 +14,10 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.TextMapPropagator;
+import org.jspecify.annotations.Nullable;
 
 import jakarta.inject.Inject;
+import java.util.Objects;
 
 /**
  * Middleware that creates OpenTelemetry spans for each HTTP request.
@@ -51,11 +53,12 @@ public class TracingMiddleware implements WebMiddleware {
             AttributeKey.stringKey("error.type");
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(
             HttpRequest request,
             MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
 
-        Tracer tracer = openTelemetry.getTracer();
+        Tracer tracer = Objects.requireNonNull(openTelemetry.getTracer(),
+                "OpenTelemetryComponent has not been started");
 
         // Extract propagated context from incoming headers
         TextMapPropagator propagator = openTelemetry.getOpenTelemetry()

--- a/enkan-component-opentelemetry/src/main/java/enkan/middleware/opentelemetry/package-info.java
+++ b/enkan-component-opentelemetry/src/main/java/enkan/middleware/opentelemetry/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.middleware.opentelemetry;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-thymeleaf/pom.xml
+++ b/enkan-component-thymeleaf/pom.xml
@@ -16,6 +16,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.thymeleaf</groupId>
             <artifactId>thymeleaf</artifactId>
             <version>3.1.5.RELEASE</version>

--- a/enkan-component-thymeleaf/src/main/java/enkan/component/thymeleaf/ThymeleafTemplateEngine.java
+++ b/enkan-component-thymeleaf/src/main/java/enkan/component/thymeleaf/ThymeleafTemplateEngine.java
@@ -16,6 +16,8 @@ import org.thymeleaf.templatemode.TemplateMode;
 import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
 import org.thymeleaf.templateresolver.ITemplateResolver;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.ByteArrayInputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
@@ -32,28 +34,29 @@ import java.util.function.Function;
 public class ThymeleafTemplateEngine extends TemplateEngine<ThymeleafTemplateEngine> {
     private String prefix = "templates/";
     private String suffix = ".html";
-    private ClassLoader classLoader;
+    private @Nullable ClassLoader classLoader;
     private Charset charset = StandardCharsets.UTF_8;
     private Locale locale = Locale.getDefault();
 
-    private Set<IDialect> dialects;
-    private Set<ITemplateResolver> templateResolvers;
-    private Set<IMessageResolver> messageResolvers;
-    private Set<ILinkBuilder> linkBuilders;
+    private @Nullable Set<IDialect> dialects;
+    private @Nullable Set<ITemplateResolver> templateResolvers;
+    private @Nullable Set<IMessageResolver> messageResolvers;
+    private @Nullable Set<ILinkBuilder> linkBuilders;
 
-    private ICacheManager cacheManager;
+    private @Nullable ICacheManager cacheManager;
 
-    private org.thymeleaf.TemplateEngine thymeleafEngine;
+    private org.thymeleaf.@Nullable TemplateEngine thymeleafEngine;
 
     @Override
     public HttpResponse render(String name, Object... keyOrVals) {
-        if (thymeleafEngine == null) {
+        final org.thymeleaf.TemplateEngine engine = thymeleafEngine;
+        if (engine == null) {
             throw new MisconfigurationException("core.COMPONENT_NOT_FOUND", "ThymeleafTemplateEngine", getClass().getSimpleName());
         }
         TemplatedHttpResponse response = TemplatedHttpResponse.create(name, keyOrVals);
         response.setBody(new LazyRenderInputStream(() -> {
             Context ctx = new Context(locale, response.getContext());
-            return new ByteArrayInputStream(thymeleafEngine.process(name, ctx).getBytes(charset));
+            return new ByteArrayInputStream(engine.process(name, ctx).getBytes(charset));
         }));
 
         HttpResponseUtils.contentType(response, "text/html; charset=" + charset.name());

--- a/enkan-component-thymeleaf/src/main/java/enkan/component/thymeleaf/package-info.java
+++ b/enkan-component-thymeleaf/src/main/java/enkan/component/thymeleaf/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.component.thymeleaf;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-undertow/pom.xml
+++ b/enkan-component-undertow/pom.xml
@@ -20,6 +20,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-core</artifactId>
             <version>${undertow.version}</version>

--- a/enkan-component-undertow/src/main/java/enkan/component/undertow/UndertowAdapter.java
+++ b/enkan-component-undertow/src/main/java/enkan/component/undertow/UndertowAdapter.java
@@ -14,6 +14,7 @@ import enkan.exception.MisconfigurationException;
 import enkan.exception.ServiceUnavailableException;
 import enkan.exception.UnreachableException;
 import io.undertow.Undertow;
+import org.jspecify.annotations.Nullable;
 import io.undertow.io.IoCallback;
 import io.undertow.io.Sender;
 import io.undertow.server.HttpHandler;
@@ -62,7 +63,7 @@ public class UndertowAdapter {
         }
     };
 
-    private static void setBody(HttpServerExchange exchange, Object body) throws IOException {
+    private static void setBody(HttpServerExchange exchange, @Nullable Object body) throws IOException {
         switch (body) {
             case null -> {
                 // Do nothing
@@ -186,6 +187,10 @@ public class UndertowAdapter {
 
                 try {
                     HttpResponse response = application.handle(request);
+                    if (response == null) {
+                        exchange.setStatusCode(404);
+                        return;
+                    }
                     exchange.setStatusCode(response.getStatus());
                     setResponseHeaders(response.getHeaders(), exchange);
 
@@ -241,7 +246,8 @@ public class UndertowAdapter {
             KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
             KeyStore keystore = (KeyStore) options.get("keystore");
             if (keystore != null) {
-                kmf.init(keystore, options.getString("keystorePassword", "").toCharArray());
+                String keystorePassword = options.getString("keystorePassword", "");
+                kmf.init(keystore, (keystorePassword != null ? keystorePassword : "").toCharArray());
                 keyManagers = kmf.getKeyManagers();
             }
 

--- a/enkan-component-undertow/src/main/java/enkan/component/undertow/UndertowComponent.java
+++ b/enkan-component-undertow/src/main/java/enkan/component/undertow/UndertowComponent.java
@@ -11,6 +11,7 @@ import enkan.component.WebServerComponent;
 import enkan.exception.MisconfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.jspecify.annotations.Nullable;
 
 /**
  * @author kawasima
@@ -18,10 +19,10 @@ import org.slf4j.LoggerFactory;
 public class UndertowComponent extends WebServerComponent<UndertowComponent> implements HealthCheckable {
     private static final Logger LOG = LoggerFactory.getLogger(UndertowComponent.class);
 
-    private UndertowAdapter.UndertowServer server;
+    private UndertowAdapter.@Nullable UndertowServer server;
     private volatile boolean starting = false;
     private volatile boolean stopping = false;
-    private String digestAlgorithm = null;
+    private @Nullable String digestAlgorithm = null;
 
     @Override
     protected ComponentLifecycle<UndertowComponent> lifecycle() {

--- a/enkan-component-undertow/src/main/java/enkan/component/undertow/digest/CombinedDigestConduit.java
+++ b/enkan-component-undertow/src/main/java/enkan/component/undertow/digest/CombinedDigestConduit.java
@@ -5,6 +5,7 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HttpString;
 import org.xnio.conduits.AbstractStreamSinkConduit;
 import org.xnio.conduits.StreamSinkConduit;
+import org.jspecify.annotations.Nullable;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -27,8 +28,8 @@ public class CombinedDigestConduit extends AbstractStreamSinkConduit<StreamSinkC
     private static final HttpString CONTENT_DIGEST = HttpString.tryFromString("Content-Digest");
 
     private final HttpServerExchange exchange;
-    private final String reprAlgorithm;
-    private final String contentAlgorithm;
+    private final @Nullable String reprAlgorithm;
+    private final @Nullable String contentAlgorithm;
     private final ByteArrayOutputStream buffer = new ByteArrayOutputStream(4096);
 
     /**
@@ -38,7 +39,7 @@ public class CombinedDigestConduit extends AbstractStreamSinkConduit<StreamSinkC
      * @param contentAlgorithm algorithm for {@code Content-Digest}, or {@code null} to omit
      */
     public CombinedDigestConduit(StreamSinkConduit next, HttpServerExchange exchange,
-                                 String reprAlgorithm, String contentAlgorithm) {
+                                 @Nullable String reprAlgorithm, @Nullable String contentAlgorithm) {
         super(next);
         this.exchange = exchange;
         this.reprAlgorithm = reprAlgorithm;

--- a/enkan-component-undertow/src/main/java/enkan/component/undertow/digest/package-info.java
+++ b/enkan-component-undertow/src/main/java/enkan/component/undertow/digest/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.component.undertow.digest;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-component-undertow/src/main/java/enkan/component/undertow/package-info.java
+++ b/enkan-component-undertow/src/main/java/enkan/component/undertow/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.component.undertow;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-core/pom.xml
+++ b/enkan-core/pom.xml
@@ -17,6 +17,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/enkan-core/src/main/java/enkan/Application.java
+++ b/enkan-core/src/main/java/enkan/Application.java
@@ -63,9 +63,9 @@ public interface Application<AREQ, ARES> {
      * Handle a request using middleware stack in this application.
      *
      * @param req   A request object
-     * @return      A response object
+     * @return      A response object, or {@code null} if the stack yields none
      */
-    ARES handle(AREQ req);
+    @Nullable ARES handle(AREQ req);
 
     /**
      * Validate a middleware stack.

--- a/enkan-core/src/main/java/enkan/Application.java
+++ b/enkan-core/src/main/java/enkan/Application.java
@@ -3,6 +3,8 @@ package enkan;
 import enkan.exception.MisconfigurationException;
 import enkan.util.Predicates;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -55,7 +57,7 @@ public interface Application<AREQ, ARES> {
      * @param <NREQ> A type of the next request
      * @param <NRES> A type of the next response
      */
-    <REQ, RES, NREQ, NRES> void use(Predicate<? super REQ> predicate, String middlewareName, Middleware<REQ, RES, NREQ, NRES> middleware);
+    <REQ, RES, NREQ, NRES> void use(Predicate<? super REQ> predicate, @Nullable String middlewareName, Middleware<REQ, RES, NREQ, NRES> middleware);
 
     /**
      * Handle a request using middleware stack in this application.

--- a/enkan-core/src/main/java/enkan/Endpoint.java
+++ b/enkan-core/src/main/java/enkan/Endpoint.java
@@ -1,5 +1,7 @@
 package enkan;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Endpoint is a specialized middleware.
  * It doesn't have a next middleware.
@@ -13,7 +15,7 @@ public interface Endpoint<REQ, RES> extends Middleware<REQ, RES, REQ, RES> {
      * @param next  {@inheritDoc}
      * @return      {@inheritDoc}
      */
-    default <NREQ, NRES> RES handle(REQ req, MiddlewareChain<REQ, RES, NREQ, NRES> next) {
+    default <NREQ, NRES> @Nullable RES handle(REQ req, MiddlewareChain<REQ, RES, NREQ, NRES> next) {
         return handle(req);
     }
 
@@ -23,5 +25,5 @@ public interface Endpoint<REQ, RES> extends Middleware<REQ, RES, REQ, RES> {
      * @param req  A request object
      * @return     A response object
      */
-    RES handle(REQ req);
+    @Nullable RES handle(REQ req);
 }

--- a/enkan-core/src/main/java/enkan/Env.java
+++ b/enkan-core/src/main/java/enkan/Env.java
@@ -2,6 +2,8 @@ package enkan;
 
 import enkan.exception.FalteringEnvironmentException;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -74,7 +76,7 @@ public class Env {
      * @param name variable name
      * @return value, or {@code null} if the variable is not set
      */
-    public static String get(String name) {
+    public static @Nullable String get(String name) {
         return getString(name, null);
     }
 
@@ -85,7 +87,7 @@ public class Env {
      * @param defaultValue default value
      * @return value
      */
-    public static String getString(String name, String defaultValue) {
+    public static @Nullable String getString(String name, @Nullable String defaultValue) {
         String value = envMap.get(normalizeKey(name));
         return value != null ? value : defaultValue;
     }

--- a/enkan-core/src/main/java/enkan/Middleware.java
+++ b/enkan-core/src/main/java/enkan/Middleware.java
@@ -1,5 +1,7 @@
 package enkan;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Handles a request and calls the next middleware chain and  returns a response.
  *
@@ -9,9 +11,14 @@ public interface Middleware<REQ, RES, NREQ, NRES> {
     /**
      * Handles the given request.
      *
+     * <p>A middleware may return {@code null} to signal that no response was
+     * produced (for example, a decorator that passes through a {@code null}
+     * response from downstream). This is distinct from an exhausted chain,
+     * which throws rather than returning {@code null}.
+     *
      * @param req   A request object
      * @param chain A chain of middlewares
-     * @return      A response object
+     * @return      A response object, or {@code null} if none was produced
      */
-    <NNREQ, NNRES> RES handle(REQ req, MiddlewareChain<NREQ, NRES, NNREQ, NNRES> chain);
+    <NNREQ, NNRES> @Nullable RES handle(REQ req, MiddlewareChain<NREQ, NRES, NNREQ, NNRES> chain);
 }

--- a/enkan-core/src/main/java/enkan/MiddlewareChain.java
+++ b/enkan-core/src/main/java/enkan/MiddlewareChain.java
@@ -1,5 +1,7 @@
 package enkan;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.function.Predicate;
 
 /**
@@ -48,7 +50,8 @@ public interface MiddlewareChain<REQ, RES, NREQ, NRES> {
      * Process the next middleware.
      *
      * @param req  A request object
-     * @return A response object
+     * @return A response object, or {@code null} if a middleware produced none.
+     *         An exhausted chain (no middleware matched) throws instead.
      */
-    RES next(REQ req);
+    @Nullable RES next(REQ req);
 }

--- a/enkan-core/src/main/java/enkan/annotation/package-info.java
+++ b/enkan-core/src/main/java/enkan/annotation/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.annotation;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-core/src/main/java/enkan/chain/DefaultMiddlewareChain.java
+++ b/enkan-core/src/main/java/enkan/chain/DefaultMiddlewareChain.java
@@ -3,6 +3,7 @@ package enkan.chain;
 import enkan.Middleware;
 import enkan.MiddlewareChain;
 import enkan.data.Traceable;
+import enkan.exception.MisconfigurationException;
 
 import java.util.function.Predicate;
 
@@ -12,10 +13,43 @@ import java.util.function.Predicate;
  * @author kawasima
  */
 public class DefaultMiddlewareChain<REQ, RES, NREQ, NRES> implements MiddlewareChain<REQ, RES, NREQ, NRES> {
+    /**
+     * Sentinel installed as the {@code chain} of the last node in a stack.
+     * Reaching it means a request was dispatched past every middleware without
+     * any of them producing a response — always a chain-wiring mistake, so it
+     * fails loudly instead of returning {@code null}.
+     */
+    @SuppressWarnings("rawtypes")
+    private static final MiddlewareChain TERMINAL = new MiddlewareChain() {
+        @Override public MiddlewareChain setNext(MiddlewareChain next) {
+            throw new UnsupportedOperationException("terminal chain");
+        }
+        @Override public Middleware getMiddleware() {
+            throw new UnsupportedOperationException("terminal chain");
+        }
+        @Override public String getName() {
+            return "terminal";
+        }
+        @Override public Predicate getPredicate() {
+            throw new UnsupportedOperationException("terminal chain");
+        }
+        @Override public void setPredicate(Predicate predicate) {
+            throw new UnsupportedOperationException("terminal chain");
+        }
+        @Override public Object next(Object req) {
+            throw new MisconfigurationException("core.MIDDLEWARE_CHAIN_EXHAUSTED");
+        }
+    };
+
+    @SuppressWarnings("unchecked")
+    private static <A, B> MiddlewareChain<A, B, ?, ?> terminal() {
+        return (MiddlewareChain<A, B, ?, ?>) TERMINAL;
+    }
+
     private Predicate<? super REQ> predicate;
     private final Middleware<REQ, RES, NREQ, NRES> middleware;
     private final String middlewareName;
-    private MiddlewareChain<NREQ, NRES, ?, ?> chain;
+    private MiddlewareChain<NREQ, NRES, ?, ?> chain = terminal();
 
 
     /**
@@ -85,12 +119,12 @@ public class DefaultMiddlewareChain<REQ, RES, NREQ, NRES> implements MiddlewareC
             RES res = middleware.handle(req, chain);
             writeTraceLog(res, middlewareName);
             return res;
-        } else if (chain != null) {
+        } else {
+            // chain is never null: the last node keeps the TERMINAL sentinel,
+            // whose next() throws rather than yielding a null response.
             NRES res = chain.next((NREQ) req);
             writeTraceLog(res, middlewareName);
             return (RES) res;
-        } else {
-            return null;
         }
     }
 

--- a/enkan-core/src/main/java/enkan/chain/DefaultMiddlewareChain.java
+++ b/enkan-core/src/main/java/enkan/chain/DefaultMiddlewareChain.java
@@ -5,6 +5,8 @@ import enkan.MiddlewareChain;
 import enkan.data.Traceable;
 import enkan.exception.MisconfigurationException;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.function.Predicate;
 
 /**
@@ -60,7 +62,7 @@ public class DefaultMiddlewareChain<REQ, RES, NREQ, NRES> implements MiddlewareC
      * @param middlewareName  a name of middleware
      * @param middleware      a middleware
      */
-    public DefaultMiddlewareChain(Predicate<? super REQ> predicate, String middlewareName, Middleware<REQ, RES, NREQ, NRES> middleware) {
+    public DefaultMiddlewareChain(Predicate<? super REQ> predicate, @Nullable String middlewareName, Middleware<REQ, RES, NREQ, NRES> middleware) {
         this.predicate = predicate;
         this.middleware = middleware;
         enkan.annotation.Middleware anno = middleware.getClass().getAnnotation(enkan.annotation.Middleware.class);
@@ -95,7 +97,7 @@ public class DefaultMiddlewareChain<REQ, RES, NREQ, NRES> implements MiddlewareC
         return middleware;
     }
 
-    protected void writeTraceLog(Object reqOrRes, String middlewareName) {
+    protected void writeTraceLog(@Nullable Object reqOrRes, String middlewareName) {
         if (reqOrRes instanceof Traceable t) {
             t.getTraceLog().write(middlewareName);
         }
@@ -112,7 +114,7 @@ public class DefaultMiddlewareChain<REQ, RES, NREQ, NRES> implements MiddlewareC
     // unchanged, so REQ == NREQ and RES == NRES at the call site.
     @SuppressWarnings("unchecked")
     @Override
-    public RES next(REQ req) {
+    public @Nullable RES next(REQ req) {
         writeTraceLog(req, middlewareName);
 
         if (predicate.test(req)) {

--- a/enkan-core/src/main/java/enkan/chain/package-info.java
+++ b/enkan-core/src/main/java/enkan/chain/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.chain;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-core/src/main/java/enkan/collection/Multimap.java
+++ b/enkan-core/src/main/java/enkan/collection/Multimap.java
@@ -1,5 +1,7 @@
 package enkan.collection;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -80,7 +82,7 @@ public class Multimap<K, V> implements Map<K, V> {
      * {@inheritDoc}
      */
     @Override
-    public V get(Object key) {
+    public @Nullable V get(Object key) {
         List<V> values = hashMap.get(key);
         if (values == null || values.isEmpty())
             return null;
@@ -128,7 +130,7 @@ public class Multimap<K, V> implements Map<K, V> {
      * {@inheritDoc}
      */
     @Override
-    public V remove(Object key) {
+    public @Nullable V remove(Object key) {
         List<V> old = hashMap.remove(key);
         if (old != null && !old.isEmpty()) {
             return old.getFirst();
@@ -186,7 +188,7 @@ public class Multimap<K, V> implements Map<K, V> {
                     }
 
                     @Override
-                    public V getValue() {
+                    public @Nullable V getValue() {
                         List<V> values = e.getValue();
                         return (values != null && !values.isEmpty()) ? values.getFirst() : null;
                     }

--- a/enkan-core/src/main/java/enkan/collection/OptionMap.java
+++ b/enkan-core/src/main/java/enkan/collection/OptionMap.java
@@ -1,5 +1,7 @@
 package enkan.collection;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.*;
 
 /**
@@ -58,7 +60,7 @@ public class OptionMap extends HashMap<String, Object> {
      * @param key the key
      * @return the string value, or {@code null}
      */
-    public String getString(String key) {
+    public @Nullable String getString(String key) {
         return getString(key, null);
     }
 
@@ -69,7 +71,7 @@ public class OptionMap extends HashMap<String, Object> {
      * @param defaultValue the fallback value
      * @return the string value, or {@code defaultValue}
      */
-    public String getString(String key, String defaultValue) {
+    public @Nullable String getString(String key, @Nullable String defaultValue) {
         Object value = get(key);
         if (value == null) return defaultValue;
         return value.toString();

--- a/enkan-core/src/main/java/enkan/collection/OptionMap.java
+++ b/enkan-core/src/main/java/enkan/collection/OptionMap.java
@@ -43,13 +43,13 @@ public class OptionMap extends HashMap<String, Object> {
      * @return a new option map
      * @throws enkan.exception.MisconfigurationException if the array length is odd
      */
-    public static OptionMap of(Object... init) {
+    public static OptionMap of(@Nullable Object... init) {
         if (init.length % 2 != 0) {
             throw new enkan.exception.MisconfigurationException("core.MISSING_KEY_VALUE_PAIR");
         }
         OptionMap m = empty();
         for(int i = 0; i < init.length; i += 2) {
-            m.put(init[i].toString(), init[i + 1]);
+            m.put(Objects.toString(init[i]), init[i + 1]);
         }
         return m;
     }

--- a/enkan-core/src/main/java/enkan/collection/Parameters.java
+++ b/enkan-core/src/main/java/enkan/collection/Parameters.java
@@ -129,7 +129,7 @@ public class Parameters implements Map<String, Object>, Serializable {
      * @return a new parameters map with the given entries
      * @throws MisconfigurationException if the array length is odd
      */
-    public static Parameters of(Object... init) {
+    public static Parameters of(@Nullable Object... init) {
         if (init.length % 2 != 0) {
             throw new MisconfigurationException("core.MISSING_KEY_VALUE_PAIR");
         }
@@ -300,7 +300,7 @@ public class Parameters implements Map<String, Object>, Serializable {
 
     @SuppressWarnings("unchecked")
     @Override
-    public @Nullable Object put(String key, Object value) {
+    public @Nullable Object put(String key, @Nullable Object value) {
         if (!caseSensitive) {
             key = asciiLowerCase(key);
         }

--- a/enkan-core/src/main/java/enkan/collection/Parameters.java
+++ b/enkan-core/src/main/java/enkan/collection/Parameters.java
@@ -2,6 +2,8 @@ package enkan.collection;
 
 import enkan.exception.MisconfigurationException;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.Serializable;
 import java.util.*;
 
@@ -185,7 +187,7 @@ public class Parameters implements Map<String, Object>, Serializable {
      * @return {@inheritDoc}
      */
     @Override
-    public String get(Object key) {
+    public @Nullable String get(Object key) {
         if (!caseSensitive && key instanceof String s) {
             key = asciiLowerCase(s);
         }
@@ -194,7 +196,7 @@ public class Parameters implements Map<String, Object>, Serializable {
         return val.toString();
     }
 
-    private Integer keyToInt(Object key) {
+    private @Nullable Integer keyToInt(Object key) {
         int i;
         if (key instanceof Number n) {
             i = n.intValue();
@@ -215,7 +217,7 @@ public class Parameters implements Map<String, Object>, Serializable {
      * @param keys rest keys
      * @return found object
      */
-    public Object getIn(Object key, Object... keys) {
+    public @Nullable Object getIn(Object key, Object... keys) {
         int idx = 0;
         Object current = getRawType(key);
 
@@ -244,7 +246,7 @@ public class Parameters implements Map<String, Object>, Serializable {
      * @param key the key to look up
      * @return the raw value, or {@code null} if not present
      */
-    public Object getRawType(Object key) {
+    public @Nullable Object getRawType(Object key) {
         if (!caseSensitive && key instanceof String s) {
             key = asciiLowerCase(s);
         }
@@ -283,7 +285,7 @@ public class Parameters implements Map<String, Object>, Serializable {
      * @param keys the remaining keys for nested lookup
      * @return the parsed long value, or {@code null} if not present or not parseable
      */
-    public Long getLong(Object key, Object... keys) {
+    public @Nullable Long getLong(Object key, Object... keys) {
         Object value = getIn(key, keys);
         if (value == null) {
             return null;
@@ -298,7 +300,7 @@ public class Parameters implements Map<String, Object>, Serializable {
 
     @SuppressWarnings("unchecked")
     @Override
-    public Object put(String key, Object value) {
+    public @Nullable Object put(String key, Object value) {
         if (!caseSensitive) {
             key = asciiLowerCase(key);
         }
@@ -317,7 +319,7 @@ public class Parameters implements Map<String, Object>, Serializable {
     }
 
     @Override
-    public Object remove(Object key) {
+    public @Nullable Object remove(Object key) {
         if (!caseSensitive) {
             key = asciiLowerCase(key.toString());
         }
@@ -330,7 +332,7 @@ public class Parameters implements Map<String, Object>, Serializable {
     }
 
     @Override
-    public Object replace(String key, Object value) {
+    public @Nullable Object replace(String key, Object value) {
         if (!caseSensitive) {
             key = asciiLowerCase(key);
         }

--- a/enkan-core/src/main/java/enkan/collection/package-info.java
+++ b/enkan-core/src/main/java/enkan/collection/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.collection;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-core/src/main/java/enkan/data/ConversationAvailable.java
+++ b/enkan-core/src/main/java/enkan/data/ConversationAvailable.java
@@ -1,5 +1,7 @@
 package enkan.data;
 
+import org.jspecify.annotations.Nullable;
+
 import jakarta.enterprise.context.Conversation;
 
 /**
@@ -8,7 +10,7 @@ import jakarta.enterprise.context.Conversation;
  * @author kawasima
  */
 public interface ConversationAvailable extends Extendable {
-    default Conversation getConversation() {
+    default @Nullable Conversation getConversation() {
         return getExtension("conversation");
     }
 
@@ -16,7 +18,7 @@ public interface ConversationAvailable extends Extendable {
         setExtension("conversation", conversation);
     }
 
-    default ConversationState getConversationState() {
+    default @Nullable ConversationState getConversationState() {
         return getExtension("conversationState");
     }
 

--- a/enkan-core/src/main/java/enkan/data/ConversationState.java
+++ b/enkan-core/src/main/java/enkan/data/ConversationState.java
@@ -1,5 +1,7 @@
 package enkan.data;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
@@ -61,7 +63,7 @@ public class ConversationState implements Map<String, Object>, Serializable {
      * {@inheritDoc}
      */
     @Override
-    public Object get(Object key) {
+    public @Nullable Object get(Object key) {
         return attrs.get(key);
     }
 
@@ -69,7 +71,7 @@ public class ConversationState implements Map<String, Object>, Serializable {
      * {@inheritDoc}
      */
     @Override
-    public Object put(String key, Object value) {
+    public @Nullable Object put(String key, Object value) {
         return attrs.put(key, value);
     }
 
@@ -77,7 +79,7 @@ public class ConversationState implements Map<String, Object>, Serializable {
      * {@inheritDoc}
      */
     @Override
-    public Object remove(Object key) {
+    public @Nullable Object remove(Object key) {
         return attrs.remove(key);
     }
 

--- a/enkan-core/src/main/java/enkan/data/Extendable.java
+++ b/enkan-core/src/main/java/enkan/data/Extendable.java
@@ -38,5 +38,5 @@ public interface Extendable {
      * @param name      the extension key
      * @param extension the value to store
      */
-    <T> void setExtension(String name, T extension);
+    <T> void setExtension(String name, @Nullable T extension);
 }

--- a/enkan-core/src/main/java/enkan/data/Extendable.java
+++ b/enkan-core/src/main/java/enkan/data/Extendable.java
@@ -1,5 +1,7 @@
 package enkan.data;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Allows arbitrary named extensions to be attached to an object at runtime.
  *
@@ -26,7 +28,7 @@ public interface Extendable {
      * @param name the extension key
      * @return the extension value, or {@code null}
      */
-    <T> T getExtension(String name);
+    <T> @Nullable T getExtension(String name);
 
     /**
      * Binds {@code extension} to the key {@code name}, replacing any

--- a/enkan-core/src/main/java/enkan/data/FlashAvailable.java
+++ b/enkan-core/src/main/java/enkan/data/FlashAvailable.java
@@ -1,10 +1,12 @@
 package enkan.data;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * @author kawasima
  */
 public interface FlashAvailable extends Extendable {
-    default Flash<?> getFlash() {
+    default @Nullable Flash<?> getFlash() {
         return getExtension("flash");
     }
 

--- a/enkan-core/src/main/java/enkan/data/PrincipalAvailable.java
+++ b/enkan-core/src/main/java/enkan/data/PrincipalAvailable.java
@@ -1,12 +1,14 @@
 package enkan.data;
 
+import org.jspecify.annotations.Nullable;
+
 import java.security.Principal;
 
 /**
  * @author kawasima
  */
 public interface PrincipalAvailable extends Extendable {
-    default Principal getPrincipal() {
+    default @Nullable Principal getPrincipal() {
         return getExtension("principal");
     }
 

--- a/enkan-core/src/main/java/enkan/data/Session.java
+++ b/enkan-core/src/main/java/enkan/data/Session.java
@@ -1,5 +1,7 @@
 package enkan.data;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
@@ -88,7 +90,7 @@ public class Session implements Map<String, Serializable>, Serializable {
      * {@inheritDoc}
      */
     @Override
-    public Serializable get(Object key) {
+    public @Nullable Serializable get(Object key) {
         return attrs.get(key);
     }
 
@@ -96,7 +98,7 @@ public class Session implements Map<String, Serializable>, Serializable {
      * {@inheritDoc}
      */
     @Override
-    public Serializable put(String key, Serializable value) {
+    public @Nullable Serializable put(String key, Serializable value) {
         return attrs.put(key, value);
     }
 
@@ -104,7 +106,7 @@ public class Session implements Map<String, Serializable>, Serializable {
      * {@inheritDoc}
      */
     @Override
-    public Serializable remove(Object key) {
+    public @Nullable Serializable remove(Object key) {
         return attrs.remove(key);
     }
 

--- a/enkan-core/src/main/java/enkan/data/SessionAvailable.java
+++ b/enkan-core/src/main/java/enkan/data/SessionAvailable.java
@@ -1,9 +1,11 @@
 package enkan.data;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * @author kawasima
  */
 public interface SessionAvailable extends Extendable {
-    Session getSession();
-    void setSession(Session session);
+    @Nullable Session getSession();
+    void setSession(@Nullable Session session);
 }

--- a/enkan-core/src/main/java/enkan/data/UriAvailable.java
+++ b/enkan-core/src/main/java/enkan/data/UriAvailable.java
@@ -1,12 +1,14 @@
 package enkan.data;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * @author kawasima
  */
 public interface UriAvailable {
-    String getUri();
-    void setUri(String uri);
+    @Nullable String getUri();
+    void setUri(@Nullable String uri);
 
-    String getRequestMethod();
-    void setRequestMethod(String method);
+    @Nullable String getRequestMethod();
+    void setRequestMethod(@Nullable String method);
 }

--- a/enkan-core/src/main/java/enkan/data/package-info.java
+++ b/enkan-core/src/main/java/enkan/data/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.data;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-core/src/main/java/enkan/exception/MisconfigurationException.java
+++ b/enkan-core/src/main/java/enkan/exception/MisconfigurationException.java
@@ -1,5 +1,7 @@
 package enkan.exception;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -16,6 +18,7 @@ import java.util.*;
  * @author kawasima
  */
 public class MisconfigurationException extends UnrecoverableException {
+    private final String code;
     private final String problem;
     private final String solution;
 
@@ -106,11 +109,12 @@ public class MisconfigurationException extends UnrecoverableException {
         return super.getMessage() + ":" + problem;
     }
 
-    public MisconfigurationException(String code, Object... arguments) {
+    public MisconfigurationException(String code, @Nullable Object... arguments) {
         super(code, Arrays.stream(arguments)
                 .filter(arg -> arg instanceof Throwable)
                 .map(arg -> (Throwable) arg)
                 .findFirst().orElse(null));
+        this.code = code;
         String problemFmt = misconfigurationMessages.getProperty(code + ".problem", code + ".problem (message not found)");
         problem = new MessageFormat(problemFmt, Locale.getDefault()).format(arguments);
         String solutionFmt = misconfigurationMessages.getProperty(code + ".solution", code + ".solution (message not found)");
@@ -118,7 +122,7 @@ public class MisconfigurationException extends UnrecoverableException {
     }
 
     public String getCode() {
-        return super.getMessage();
+        return code;
     }
 
     public String getProblem() {

--- a/enkan-core/src/main/java/enkan/exception/UnreachableException.java
+++ b/enkan-core/src/main/java/enkan/exception/UnreachableException.java
@@ -1,5 +1,7 @@
 package enkan.exception;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Thrown when execution reaches a code path that the framework authors
  * considered impossible.
@@ -15,7 +17,7 @@ public final class UnreachableException extends UnrecoverableException {
         this(null);
     }
 
-    public UnreachableException(Throwable cause) {
+    public UnreachableException(@Nullable Throwable cause) {
         super("This exception has proved a framework bug.", cause);
     }
 }

--- a/enkan-core/src/main/java/enkan/exception/UnrecoverableException.java
+++ b/enkan-core/src/main/java/enkan/exception/UnrecoverableException.java
@@ -1,5 +1,7 @@
 package enkan.exception;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Base class for exceptions that represent a condition from which the
  * application cannot meaningfully recover at runtime.
@@ -18,7 +20,7 @@ package enkan.exception;
  * @author kawasima
  */
 public abstract class UnrecoverableException extends RuntimeException {
-    protected UnrecoverableException(String message, Throwable cause) {
+    protected UnrecoverableException(String message, @Nullable Throwable cause) {
         super(message, cause);
     }
 

--- a/enkan-core/src/main/java/enkan/exception/package-info.java
+++ b/enkan-core/src/main/java/enkan/exception/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.exception;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-core/src/main/java/enkan/middleware/AuthenticationMiddleware.java
+++ b/enkan-core/src/main/java/enkan/middleware/AuthenticationMiddleware.java
@@ -8,6 +8,8 @@ import enkan.security.AuthBackend;
 import enkan.util.MixinUtils;
 import enkan.util.ThreadingUtils;
 
+import org.jspecify.annotations.Nullable;
+
 import java.security.Principal;
 import java.util.List;
 import java.util.Optional;
@@ -29,7 +31,7 @@ public class AuthenticationMiddleware<REQ, RES, T> implements DecoratorMiddlewar
     }
 
     @Override
-    public <NNREQ, NNRES> RES handle(REQ req, MiddlewareChain<REQ, RES, NNREQ, NNRES> next) {
+    public <NNREQ, NNRES> @Nullable RES handle(REQ req, MiddlewareChain<REQ, RES, NNREQ, NNRES> next) {
         final REQ request = MixinUtils.mixin(req, PrincipalAvailable.class);
         for (AuthBackend<REQ, T> backend : backends) {
             try {

--- a/enkan-core/src/main/java/enkan/middleware/LazyLoadMiddleware.java
+++ b/enkan-core/src/main/java/enkan/middleware/LazyLoadMiddleware.java
@@ -34,7 +34,7 @@ public class LazyLoadMiddleware<REQ, RES, NREQ, NRES> implements Middleware<REQ,
      */
     @SuppressWarnings("unchecked")
     @Override
-    public <NNREQ, NNRES> RES handle(REQ request, MiddlewareChain<NREQ, NRES, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable RES handle(REQ request, MiddlewareChain<NREQ, NRES, NNREQ, NNRES> chain) {
         Middleware<REQ, RES, NREQ, NRES> loaded = instance;
         if (loaded == null) {
             initializingLock.lock();

--- a/enkan-core/src/main/java/enkan/middleware/LazyLoadMiddleware.java
+++ b/enkan-core/src/main/java/enkan/middleware/LazyLoadMiddleware.java
@@ -3,6 +3,8 @@ package enkan.middleware;
 import enkan.Middleware;
 import enkan.MiddlewareChain;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -19,7 +21,7 @@ import static enkan.util.ReflectionUtils.tryReflection;
  * @author kawasima
  */
 public class LazyLoadMiddleware<REQ, RES, NREQ, NRES> implements Middleware<REQ, RES, NREQ, NRES> {
-    private volatile Middleware<REQ, RES, NREQ, NRES> instance;
+    private volatile @Nullable Middleware<REQ, RES, NREQ, NRES> instance;
     private final Lock initializingLock = new ReentrantLock();
     private final String middlewareClassName;
 
@@ -33,21 +35,24 @@ public class LazyLoadMiddleware<REQ, RES, NREQ, NRES> implements Middleware<REQ,
     @SuppressWarnings("unchecked")
     @Override
     public <NNREQ, NNRES> RES handle(REQ request, MiddlewareChain<NREQ, NRES, NNREQ, NNRES> chain) {
-        if (instance == null) {
+        Middleware<REQ, RES, NREQ, NRES> loaded = instance;
+        if (loaded == null) {
             initializingLock.lock();
             try {
                 // Re-check after acquiring the lock (double-checked locking).
                 // volatile guarantees the write in another thread is visible here.
-                if (instance == null) {
-                    instance = tryReflection(() -> {
+                loaded = instance;
+                if (loaded == null) {
+                    loaded = tryReflection(() -> {
                         Class<Middleware<REQ, RES, NREQ, NRES>> middlewareClass = (Class<Middleware<REQ, RES, NREQ, NRES>>) Class.forName(middlewareClassName);
                         return middlewareClass.getConstructor().newInstance();
                     });
+                    instance = loaded;
                 }
             } finally {
                 initializingLock.unlock();
             }
         }
-        return instance.handle(request, chain);
+        return loaded.handle(request, chain);
     }
 }

--- a/enkan-core/src/main/java/enkan/middleware/ServiceUnavailableMiddleware.java
+++ b/enkan-core/src/main/java/enkan/middleware/ServiceUnavailableMiddleware.java
@@ -5,6 +5,8 @@ import enkan.DecoratorMiddleware;
 import enkan.MiddlewareChain;
 import enkan.exception.ServiceUnavailableException;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * @author kawasima
  */
@@ -17,7 +19,7 @@ public class ServiceUnavailableMiddleware<REQ, RES> implements DecoratorMiddlewa
     }
 
     @Override
-    public <NNREQ, NNRES> RES handle(REQ req, MiddlewareChain<REQ, RES, NNREQ, NNRES> next) {
+    public <NNREQ, NNRES> @Nullable RES handle(REQ req, MiddlewareChain<REQ, RES, NNREQ, NNRES> next) {
         if (endpoint != null) {
             return endpoint.handle(req);
         }

--- a/enkan-core/src/main/java/enkan/middleware/package-info.java
+++ b/enkan-core/src/main/java/enkan/middleware/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.middleware;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-core/src/main/java/enkan/package-info.java
+++ b/enkan-core/src/main/java/enkan/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-core/src/main/java/enkan/predicate/package-info.java
+++ b/enkan-core/src/main/java/enkan/predicate/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.predicate;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-core/src/main/java/enkan/security/AuthBackend.java
+++ b/enkan-core/src/main/java/enkan/security/AuthBackend.java
@@ -1,5 +1,7 @@
 package enkan.security;
 
+import org.jspecify.annotations.Nullable;
+
 import java.security.Principal;
 
 /**
@@ -10,16 +12,16 @@ public interface AuthBackend<REQ, T> {
      * Parse the given request for eliciting an authentication data.
      *
      * @param request the given request
-     * @return authenticationData
+     * @return authenticationData, or {@code null} if none could be elicited
      */
-    T parse(REQ request);
+    @Nullable T parse(REQ request);
 
     /**
      * Authenticate the given request.
      *
      * @param request the given request
      * @param authenticationData authentication data
-     * @return a principal when authentication is success
+     * @return a principal when authentication is success, or {@code null} otherwise
      */
-    Principal authenticate(REQ request, T authenticationData);
+    @Nullable Principal authenticate(REQ request, T authenticationData);
 }

--- a/enkan-core/src/main/java/enkan/security/crypto/CryptoAlgorithm.java
+++ b/enkan-core/src/main/java/enkan/security/crypto/CryptoAlgorithm.java
@@ -1,5 +1,7 @@
 package enkan.security.crypto;
 
+import org.jspecify.annotations.Nullable;
+
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.PSSParameterSpec;
@@ -66,7 +68,7 @@ public enum CryptoAlgorithm {
      * <p>RSA-PSS variants require a {@link PSSParameterSpec} to select the
      * correct hash and MGF1 configuration.
      */
-    public AlgorithmParameterSpec parameterSpec() {
+    public @Nullable AlgorithmParameterSpec parameterSpec() {
         return switch (this) {
             case RSA_PSS_SHA256 -> new PSSParameterSpec("SHA-256", "MGF1",
                     MGF1ParameterSpec.SHA256, 32, 1);

--- a/enkan-core/src/main/java/enkan/security/crypto/EcdsaUtils.java
+++ b/enkan-core/src/main/java/enkan/security/crypto/EcdsaUtils.java
@@ -1,5 +1,7 @@
 package enkan.security.crypto;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Converts ECDSA signatures between DER encoding (used by JCA) and
  * IEEE P1363 / raw R||S format (used by JWS RFC 7518 §3.4 and other protocols).
@@ -31,7 +33,7 @@ public final class EcdsaUtils {
      * @param keyBits the EC key size in bits (e.g. 256, 384, 521)
      * @return the raw R||S signature, or {@code null} if the input is malformed
      */
-    public static byte[] derToP1363(byte[] der, int keyBits) {
+    public static byte @Nullable [] derToP1363(byte[] der, int keyBits) {
         int componentLen = (keyBits + 7) / 8;
         if (der == null || der.length < 8) return null;
         if (der[0] != 0x30) return null; // must be SEQUENCE tag
@@ -106,7 +108,7 @@ public final class EcdsaUtils {
      * @param p1363 the raw R||S signature (must have even length)
      * @return the DER-encoded signature, or {@code null} if the input is malformed
      */
-    public static byte[] p1363ToDer(byte[] p1363) {
+    public static byte @Nullable [] p1363ToDer(byte[] p1363) {
         if (p1363 == null || p1363.length == 0 || (p1363.length % 2) != 0) {
             return null;
         }

--- a/enkan-core/src/main/java/enkan/security/crypto/package-info.java
+++ b/enkan-core/src/main/java/enkan/security/crypto/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.security.crypto;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-core/src/main/java/enkan/security/package-info.java
+++ b/enkan-core/src/main/java/enkan/security/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.security;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-core/src/main/java/enkan/util/BeanBuilder.java
+++ b/enkan-core/src/main/java/enkan/util/BeanBuilder.java
@@ -2,6 +2,8 @@ package enkan.util;
 
 import enkan.exception.MisconfigurationException;
 
+import org.jspecify.annotations.Nullable;
+
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
@@ -16,9 +18,9 @@ import java.util.stream.Collectors;
  * @author kawasima
  */
 public class BeanBuilder<X> {
-    private static final Validator DEFAULT_VALIDATOR = createValidator();
+    private static final @Nullable Validator DEFAULT_VALIDATOR = createValidator();
 
-    private static Validator createValidator() {
+    private static @Nullable Validator createValidator() {
         try {
             ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
             Runtime.getRuntime().addShutdownHook(new Thread(factory::close,

--- a/enkan-core/src/main/java/enkan/util/MimeTypeUtils.java
+++ b/enkan-core/src/main/java/enkan/util/MimeTypeUtils.java
@@ -1,5 +1,7 @@
 package enkan.util;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -97,7 +99,7 @@ public class MimeTypeUtils {
         put("zip", "application/zip");
     }};
 
-    private static String filenameExt(String filename) {
+    private static @Nullable String filenameExt(String filename) {
         int idx = filename.lastIndexOf('.');
         if (idx == -1 || idx == filename.length() - 1) {
             return null;
@@ -107,7 +109,7 @@ public class MimeTypeUtils {
 
     }
 
-    public static String extMimeType(String filename) {
+    public static @Nullable String extMimeType(String filename) {
         String ext = filenameExt(filename);
         return ext != null ? DEFAULT_MIME_TYPES.get(ext) : null;
     }

--- a/enkan-core/src/main/java/enkan/util/MixinUtils.java
+++ b/enkan-core/src/main/java/enkan/util/MixinUtils.java
@@ -143,7 +143,6 @@ public class MixinUtils {
     }
 
     static Class<?>[] getAllInterfaces(final Class<?> clazz) {
-        if (clazz == null) return null;
         return allInterfacesCache.computeIfAbsent(clazz, c -> {
             final LinkedHashSet<Class<?>> interfacesFound = new LinkedHashSet<>();
             getAllInterfaces(c, interfacesFound);
@@ -161,15 +160,13 @@ public class MixinUtils {
      * returned unchanged without creating a proxy.
      *
      * @param <T>        the type of the target object
-     * @param target     the object to augment; {@code null} is returned as-is
+     * @param target     the object to augment
      * @param interfaces one or more interfaces to add to the proxy
      * @return a proxy implementing all original interfaces plus the requested
      *         ones, or {@code target} itself if no new interfaces are needed
      */
     @SuppressWarnings("unchecked")
     public static <T> T mixin(T target, Class<?>... interfaces) {
-        if (target == null) return null;
-
         final Class<?> targetClass = target.getClass();
         boolean allPresent = true;
         for (Class<?> iface : interfaces) {

--- a/enkan-core/src/main/java/enkan/util/ThreadingFunction.java
+++ b/enkan-core/src/main/java/enkan/util/ThreadingFunction.java
@@ -1,5 +1,7 @@
 package enkan.util;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * ThreadingFunction is a functional interface that can throw an exception.
  *
@@ -7,5 +9,5 @@ package enkan.util;
  */
 @FunctionalInterface
 public interface ThreadingFunction<T, R> {
-    R apply(T t) throws Exception;
+    @Nullable R apply(T t) throws Exception;
 }

--- a/enkan-core/src/main/java/enkan/util/ThreadingUtils.java
+++ b/enkan-core/src/main/java/enkan/util/ThreadingUtils.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 import java.util.SequencedCollection;
 import java.util.Set;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Represents the utility class for threading functions.
  *
@@ -23,7 +25,7 @@ public class ThreadingUtils {
                     UnsupportedCharsetException.class);
 
     @SuppressWarnings("unchecked")
-    private static <X, Y> Optional<Y> doSome(X start, ThreadingFunction<?,?>... functions) {
+    private static <X, Y> Optional<Y> doSome(@Nullable X start, ThreadingFunction<?,?>... functions) {
         if (functions == null || start == null) {
             return Optional.ofNullable((Y) start);
         }
@@ -59,7 +61,7 @@ public class ThreadingUtils {
      * @param <X> the type of the start value
      * @param <Y> the type of the result value
      */
-    public static <X, Y> Optional<Y> some(X start, ThreadingFunction<X, Y> f1) {
+    public static <X, Y> Optional<Y> some(@Nullable X start, ThreadingFunction<X, Y> f1) {
         return doSome(start, f1);
     }
 
@@ -74,7 +76,7 @@ public class ThreadingUtils {
      * @param <X1> the type of the intermediate value
      * @param <Y> the type of the result value
      */
-    public static <X0, X1, Y> Optional<Y> some(X0 start, ThreadingFunction<X0, X1> f1, ThreadingFunction<X1, Y> f2) {
+    public static <X0, X1, Y> Optional<Y> some(@Nullable X0 start, ThreadingFunction<X0, X1> f1, ThreadingFunction<X1, Y> f2) {
         return doSome(start, f1, f2);
     }
 
@@ -90,7 +92,7 @@ public class ThreadingUtils {
      * @param <X2> the type of the intermediate value
      * @param <Y> the type of the result value
      */
-    public static <X0, X1, X2, Y> Optional<Y> some(X0 start,
+    public static <X0, X1, X2, Y> Optional<Y> some(@Nullable X0 start,
                                          ThreadingFunction<X0, X1> f1,
                                          ThreadingFunction<X1, X2> f2,
                                          ThreadingFunction<X2, Y> f3) {
@@ -112,7 +114,7 @@ public class ThreadingUtils {
      * @param <Y> the type of the result value
      */
     public static <X0, X1, X2, X3, Y> Optional<Y> some(
-            X0 start,
+            @Nullable X0 start,
             ThreadingFunction<X0, X1> f1,
             ThreadingFunction<X1, X2> f2,
             ThreadingFunction<X2, X3> f3,

--- a/enkan-core/src/main/java/enkan/util/package-info.java
+++ b/enkan-core/src/main/java/enkan/util/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.util;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-core/src/main/java/module-info.java
+++ b/enkan-core/src/main/java/module-info.java
@@ -16,6 +16,7 @@ module enkan.core {
     requires jakarta.validation;
     requires java.logging;
     requires org.slf4j;
+    requires transitive org.jspecify;
 
     // MixinUtils.lookupSpecial() uses privateLookupIn on interfaces in enkan.util.
     // org.hibernate.validator needs access for field-level constraint validation on

--- a/enkan-core/src/main/resources/META-INF/misconfiguration.properties
+++ b/enkan-core/src/main/resources/META-INF/misconfiguration.properties
@@ -72,3 +72,5 @@ core.INJECT_CLASSLOADER_MISMATCH.problem=Type {0} is loaded by different classlo
 core.INJECT_CLASSLOADER_MISMATCH.solution=Ensure the component class is not in a reload-target directory (contains META-INF/reload.xml), or move it to a separate JAR module.
 crypto.INCOMPATIBLE_KEY_TYPE.problem=Key type {1} is incompatible with algorithm {0}.
 crypto.INCOMPATIBLE_KEY_TYPE.solution=Use a SecretKey for HMAC algorithms and a PrivateKey/PublicKey for asymmetric algorithms.
+core.MIDDLEWARE_CHAIN_EXHAUSTED.problem=The middleware chain ended without producing a response for the request.
+core.MIDDLEWARE_CHAIN_EXHAUSTED.solution=Terminate the stack with a middleware whose predicate accepts every request (for example an endpoint using Predicates.any()).

--- a/enkan-core/src/main/resources/META-INF/misconfiguration_ja.properties
+++ b/enkan-core/src/main/resources/META-INF/misconfiguration_ja.properties
@@ -55,3 +55,5 @@ core.INJECT_CLASSLOADER_MISMATCH.problem=型 {0} が異なるクラスローダ�
 core.INJECT_CLASSLOADER_MISMATCH.solution=コンポーネントクラスがリロード対象ディレクトリ (META-INF/reload.xml を含む) に存在しないことを確認するか、別のJARモジュールに移動してください。
 crypto.INCOMPATIBLE_KEY_TYPE.problem=キー型 {1} はアルゴリズム {0} と互換性がありません。
 crypto.INCOMPATIBLE_KEY_TYPE.solution=HMACアルゴリズムにはSecretKeyを、非対称アルゴリズムにはPrivateKey/PublicKeyを使用してください。
+core.MIDDLEWARE_CHAIN_EXHAUSTED.problem=ミドルウェアチェインがリクエストに対するレスポンスを生成せずに終端に達しました。
+core.MIDDLEWARE_CHAIN_EXHAUSTED.solution=すべてのリクエストを受理する述語を持つミドルウェア（例: Predicates.any() を使うエンドポイント）でスタックを終端してください。

--- a/enkan-devel-gradle/pom.xml
+++ b/enkan-devel-gradle/pom.xml
@@ -22,6 +22,10 @@
     </repositories>
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.unit8.enkan</groupId>
             <artifactId>enkan-web</artifactId>
         </dependency>

--- a/enkan-devel-gradle/src/main/java/enkan/system/devel/compiler/GradleCompiler.java
+++ b/enkan-devel-gradle/src/main/java/enkan/system/devel/compiler/GradleCompiler.java
@@ -7,6 +7,7 @@ import enkan.system.Transport;
 import enkan.system.devel.CompileResult;
 import enkan.system.devel.Compiler;
 import org.gradle.tooling.*;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +31,7 @@ public class GradleCompiler implements Compiler {
     private static final Logger LOG = LoggerFactory.getLogger(GradleCompiler.class);
 
     private String projectDirectory = ".";
-    private String gradleVersion = null;
+    private @Nullable String gradleVersion = null;
 
     @Override
     public CompileResult execute(Transport t) {

--- a/enkan-devel-gradle/src/main/java/enkan/system/devel/compiler/package-info.java
+++ b/enkan-devel-gradle/src/main/java/enkan/system/devel/compiler/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.system.devel.compiler;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-devel/pom.xml
+++ b/enkan-devel/pom.xml
@@ -16,6 +16,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.unit8.enkan</groupId>
             <artifactId>enkan-web</artifactId>
         </dependency>

--- a/enkan-devel/src/main/java/enkan/endpoint/devel/ReplConsoleEndpoint.java
+++ b/enkan-devel/src/main/java/enkan/endpoint/devel/ReplConsoleEndpoint.java
@@ -6,6 +6,8 @@ import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
 import enkan.web.util.HttpResponseUtils;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Map;
 
 /**
@@ -30,9 +32,9 @@ public class ReplConsoleEndpoint implements Endpoint<HttpRequest, HttpResponse> 
     );
 
     @Override
-    public HttpResponse handle(HttpRequest request) {
+    public @Nullable HttpResponse handle(HttpRequest request) {
         String uri = request.getUri();
-        if (!uri.startsWith(MOUNT_PATH)) {
+        if (uri == null || !uri.startsWith(MOUNT_PATH)) {
             return null;
         }
 

--- a/enkan-devel/src/main/java/enkan/endpoint/devel/package-info.java
+++ b/enkan-devel/src/main/java/enkan/endpoint/devel/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.endpoint.devel;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-devel/src/main/java/enkan/middleware/devel/HttpStatusCatMiddleware.java
+++ b/enkan-devel/src/main/java/enkan/middleware/devel/HttpStatusCatMiddleware.java
@@ -11,6 +11,8 @@ import net.unit8.moshas.MoshasEngine;
 import net.unit8.moshas.Template;
 import net.unit8.moshas.context.Context;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.StringWriter;
 
 import static enkan.web.util.HttpResponseUtils.*;
@@ -36,7 +38,7 @@ public class HttpStatusCatMiddleware implements WebMiddleware {
     }
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
         HttpResponse response = castToHttpResponse(chain.next(request));
         if (response != null && (isEmptyBody(response) || isMoreCats(response))) {
             String type = getHeader(response, "Content-Type");

--- a/enkan-devel/src/main/java/enkan/middleware/devel/StacktraceMiddleware.java
+++ b/enkan-devel/src/main/java/enkan/middleware/devel/StacktraceMiddleware.java
@@ -15,6 +15,7 @@ import net.unit8.moshas.Snippet;
 import net.unit8.moshas.Template;
 import net.unit8.moshas.context.Context;
 
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -153,7 +154,8 @@ public class StacktraceMiddleware implements WebMiddleware {
      * @return HttpResponse
      */
     protected HttpResponse exResponse(HttpRequest request, Throwable ex) {
-        String accept = request.getHeaders().get("accept");
+        Headers headers = request.getHeaders();
+        String accept = headers != null ? headers.get("accept") : null;
         if (accept != null && accept.stripLeading().regionMatches(true, 0, "text/javascript", 0, "text/javascript".length())) {
             StringWriter sw = new StringWriter();
             ex.printStackTrace(new PrintWriter(sw));
@@ -182,7 +184,7 @@ public class StacktraceMiddleware implements WebMiddleware {
      * @param <NNRES> A response object
      */
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
         try {
             return castToHttpResponse(chain.next(request));
         } catch (Throwable t) {

--- a/enkan-devel/src/main/java/enkan/middleware/devel/TraceWebMiddleware.java
+++ b/enkan-devel/src/main/java/enkan/middleware/devel/TraceWebMiddleware.java
@@ -18,6 +18,8 @@ import enkan.web.middleware.session.MemoryStore;
 import enkan.util.MixinUtils;
 import net.unit8.moshas.MoshasEngine;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.Serializable;
@@ -41,27 +43,27 @@ public class TraceWebMiddleware implements WebMiddleware, Closeable {
     private int storeSize = 100;
 
     public static class ElapseTime {
-        private Long inbound;
-        private Long outbound;
+        private @Nullable Long inbound;
+        private @Nullable Long outbound;
         private final String middlewareName;
 
         public ElapseTime(String middlewareName) {
             this.middlewareName = middlewareName;
         }
 
-        public void setInboundElapse(Long elapse) {
+        public void setInboundElapse(@Nullable Long elapse) {
             this.inbound = elapse;
         }
 
-        public void setOutboundElapse(Long elapse) {
+        public void setOutboundElapse(@Nullable Long elapse) {
             this.outbound = elapse;
         }
 
-        public Long getInboundElapse() {
+        public @Nullable Long getInboundElapse() {
             return inbound;
         }
 
-        public Long getOutboundElapse() {
+        public @Nullable Long getOutboundElapse() {
             return outbound;
         }
 
@@ -89,7 +91,8 @@ public class TraceWebMiddleware implements WebMiddleware, Closeable {
             }
         });
         routing.add("/[a-z0-9\\-]+", (req, os) -> {
-            String id = req.getUri().substring(req.getUri().lastIndexOf("/") + 1);
+            String reqUri = Objects.requireNonNull(req.getUri());
+            String id = reqUri.substring(reqUri.lastIndexOf("/") + 1);
             RequestLog requestLog = (RequestLog) store.read(id);
             if (requestLog == null) {
                 throw new TraceRouting.RouteNotFoundException();
@@ -120,21 +123,29 @@ public class TraceWebMiddleware implements WebMiddleware, Closeable {
     }
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
-        if (request.getUri().startsWith(mountPath + "/")) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
+        String uri = request.getUri();
+        if (uri != null && uri.startsWith(mountPath + "/")) {
             return traceRouting.handle(request);
         } else {
             request = MixinUtils.mixin(request, Traceable.class);
             HttpResponse response = castToHttpResponse(chain.next(request));
             Traceable requestTrace  = request;
             synchronized (this) {
-                if (idList.size() >= storeSize) {
-                    LogKey oldestLogKey = idList.removeLast();
-                    store.delete(oldestLogKey.getId());
+                // Only record completed requests (a middleware may pass null through).
+                if (response != null) {
+                    if (idList.size() >= storeSize) {
+                        LogKey oldestLogKey = idList.removeLast();
+                        store.delete(oldestLogKey.getId());
+                    }
+                    idList.addFirst(new LogKey(requestTrace.getId(),
+                            Objects.requireNonNull(request.getRequestMethod()),
+                            Objects.requireNonNull(request.getUri())));
+                    store.write(requestTrace.getId(), new RequestLog(
+                            Objects.requireNonNull(request.getHeaders()),
+                            Objects.requireNonNull(request.getParams()),
+                            requestTrace.getTraceLog(), response.getTraceLog()));
                 }
-                idList.addFirst(new LogKey(requestTrace.getId(), request.getRequestMethod(), request.getUri()));
-                store.write(requestTrace.getId(), new RequestLog(request.getHeaders(), request.getParams(),
-                        requestTrace.getTraceLog(), response.getTraceLog()));
             }
 
             return response;

--- a/enkan-devel/src/main/java/enkan/middleware/devel/package-info.java
+++ b/enkan-devel/src/main/java/enkan/middleware/devel/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.middleware.devel;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-devel/src/main/java/enkan/system/devel/ClassWatcher.java
+++ b/enkan-devel/src/main/java/enkan/system/devel/ClassWatcher.java
@@ -70,7 +70,9 @@ public class ClassWatcher implements Runnable, Closeable {
                 if (kind == StandardWatchEventKinds.OVERFLOW) continue;
 
                 @SuppressWarnings("unchecked") WatchEvent<Path> pathEvent = (WatchEvent<Path>) event;
-                Path path = watchings.get(key).resolve(pathEvent.context());
+                Path watchDir = watchings.get(key);
+                if (watchDir == null) continue;
+                Path path = watchDir.resolve(pathEvent.context());
 
                 if (kind == ENTRY_MODIFY) {
                     if (!path.toFile().isDirectory()) {

--- a/enkan-devel/src/main/java/enkan/system/devel/CompileResult.java
+++ b/enkan-devel/src/main/java/enkan/system/devel/CompileResult.java
@@ -1,5 +1,7 @@
 package enkan.system.devel;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.Serializable;
 
 /**
@@ -7,7 +9,7 @@ import java.io.Serializable;
  *
  * @author kawasima
  */
-public record CompileResult(Throwable executionException) implements Serializable {
+public record CompileResult(@Nullable Throwable executionException) implements Serializable {
     public static CompileResult success() {
         return new CompileResult(null);
     }

--- a/enkan-devel/src/main/java/enkan/system/devel/command/AutoResetCommand.java
+++ b/enkan-devel/src/main/java/enkan/system/devel/command/AutoResetCommand.java
@@ -7,6 +7,8 @@ import enkan.system.SystemCommand;
 import enkan.system.Transport;
 import enkan.system.devel.ClassWatcher;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -31,7 +33,7 @@ public class AutoResetCommand implements SystemCommand {
     }
 
     @Override
-    public boolean execute(EnkanSystem system, Transport transport, String... args) {
+    public boolean execute(@Nullable EnkanSystem system, Transport transport, String... args) {
         if (args.length > 0 && "stop".equalsIgnoreCase(args[0])) {
             Future<?> watcher = repl.getBackground("classWatcher");
             if (watcher == null) {

--- a/enkan-devel/src/main/java/enkan/system/devel/command/CompileCommand.java
+++ b/enkan-devel/src/main/java/enkan/system/devel/command/CompileCommand.java
@@ -7,6 +7,8 @@ import enkan.system.devel.CompileResult;
 import enkan.system.devel.Compiler;
 import enkan.system.devel.compiler.MavenCompiler;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
@@ -26,7 +28,7 @@ public class CompileCommand implements SystemCommand {
     }
 
     @Override
-    public boolean execute(EnkanSystem system, Transport transport, String... args) {
+    public boolean execute(@Nullable EnkanSystem system, Transport transport, String... args) {
         final CompileResult result = compiler.execute(transport);
         Throwable exception = result.executionException();
         if (exception == null) {

--- a/enkan-devel/src/main/java/enkan/system/devel/command/package-info.java
+++ b/enkan-devel/src/main/java/enkan/system/devel/command/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.system.devel.command;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-devel/src/main/java/enkan/system/devel/compiler/package-info.java
+++ b/enkan-devel/src/main/java/enkan/system/devel/compiler/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.system.devel.compiler;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-devel/src/main/java/enkan/system/devel/package-info.java
+++ b/enkan-devel/src/main/java/enkan/system/devel/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.system.devel;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-repl-client/pom.xml
+++ b/enkan-repl-client/pom.xml
@@ -97,6 +97,10 @@ exit 0
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.unit8.enkan</groupId>
             <artifactId>enkan-repl</artifactId>
             <version>${enkan.version}</version>

--- a/enkan-repl-client/src/main/java/enkan/system/repl/client/JLineTransport.java
+++ b/enkan-repl-client/src/main/java/enkan/system/repl/client/JLineTransport.java
@@ -5,6 +5,7 @@ import enkan.system.Transport;
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
 import org.jline.reader.UserInterruptException;
+import org.jspecify.annotations.Nullable;
 
 import java.io.PrintWriter;
 import java.util.concurrent.Executors;
@@ -41,9 +42,9 @@ public class JLineTransport implements Transport, AutoCloseable {
                 t.setDaemon(true);
                 return t;
             });
-    private ScheduledFuture<?> spinnerFuture;
+    private @Nullable ScheduledFuture<?> spinnerFuture;
     private final AtomicInteger spinnerTick = new AtomicInteger(0);
-    private volatile Consumer<Integer> connectCallback;
+    private volatile @Nullable Consumer<Integer> connectCallback;
 
     public JLineTransport(LineReader reader) {
         this.reader = reader;
@@ -68,7 +69,7 @@ public class JLineTransport implements Transport, AutoCloseable {
     }
 
     @Override
-    public String recv(long timeout) {
+    public @Nullable String recv(long timeout) {
         try {
             String p = pendingPrompt;
             pendingPrompt = "";

--- a/enkan-repl-client/src/main/java/enkan/system/repl/client/ReplClient.java
+++ b/enkan-repl-client/src/main/java/enkan/system/repl/client/ReplClient.java
@@ -7,6 +7,7 @@ import enkan.system.repl.serdes.Fressian;
 import enkan.system.repl.serdes.ReplResponseReader;
 import enkan.system.repl.serdes.ReplResponseWriter;
 import enkan.system.repl.serdes.ResponseStatusReader;
+import org.jspecify.annotations.Nullable;
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
@@ -47,16 +48,16 @@ public class ReplClient {
     private static final String LOCAL_HELP_HEADER = "Client commands (available without server connection):";
     private static final Map<String, String> LOCAL_COMMAND_HELP = createLocalCommandHelp();
     private final ExecutorService clientThread = Executors.newSingleThreadExecutor();
-    private ConsoleHandler consoleHandler;
+    private @Nullable ConsoleHandler consoleHandler;
 
     /** Package-private so tests in the same package can drive {@code connect()}
      *  directly without spinning up the full {@link ReplClient} CLI loop. */
     static class ConsoleHandler implements Runnable {
         private static final String MONITOR_ADDRESS = "inproc://monitor-";
-        private ZContext ctx;
-        private volatile ZMQ.Socket socket;
-        private volatile ZMQ.Socket rendererSock;
-        private volatile ZMQ.Socket completerSock;
+        private @Nullable ZContext ctx;
+        private volatile ZMQ.@Nullable Socket socket;
+        private volatile ZMQ.@Nullable Socket rendererSock;
+        private volatile ZMQ.@Nullable Socket completerSock;
         private final LineReader reader;
         private final Fressian fressian;
         private final Map<String, SystemCommand> clientLocalCommands = new LinkedHashMap<>();
@@ -103,15 +104,18 @@ public class ReplClient {
             // Guard against a race where closeSockets() nulls ctx between here and
             // createSocket(). If the REPL is already shutting down, skip the attempt.
             if (!isAvailable.get()) return;
+            // Capture ctx once: closeSockets() may null it concurrently on shutdown.
+            final ZContext zctx = ctx;
+            if (zctx == null) return;
             // Build all per-attempt state on the stack so a failure leaves the
             // existing connection (and the REPL itself) untouched. Only after
             // the completer handshake succeeds do we publish the new sockets to
             // instance fields.
-            final ZMQ.Socket newSocket = ctx.createSocket(SocketType.DEALER);
+            final ZMQ.Socket newSocket = zctx.createSocket(SocketType.DEALER);
             newSocket.setLinger(0);
 
             newSocket.connect("tcp://" + host + ":" + port);
-            final ZMQ.Poller poller = ctx.createPoller(1);
+            final ZMQ.Poller poller = zctx.createPoller(1);
             poller.register(newSocket, ZMQ.Poller.POLLIN);
             newSocket.send("/completer");
 
@@ -148,7 +152,7 @@ public class ReplClient {
             final String monitorAddress = MONITOR_ADDRESS + UUID.randomUUID();
             if (newSocket.monitor(monitorAddress, ZMQ.EVENT_DISCONNECTED | ZMQ.EVENT_CLOSED)) {
                 ZThread.start(args -> {
-                    ZMQ.Socket monSock = ctx.createSocket(SocketType.PAIR);
+                    ZMQ.Socket monSock = zctx.createSocket(SocketType.PAIR);
                     monSock.setLinger(0);
                     monSock.connect(monitorAddress);
                     try {
@@ -183,7 +187,7 @@ public class ReplClient {
             String completerPort = completerRes.getOut();
             ZMQ.Socket newCompleterSock = null;
             if (completerPort != null && completerPort.matches("\\d+")) {
-                newCompleterSock = ctx.createSocket(SocketType.DEALER);
+                newCompleterSock = zctx.createSocket(SocketType.DEALER);
                 newCompleterSock.connect("tcp://" + host + ":" + Integer.parseInt(completerPort));
                 if (reader instanceof org.jline.reader.impl.LineReaderImpl impl) {
                     RemoteCompleter completer = new RemoteCompleter(newCompleterSock);

--- a/enkan-repl-client/src/main/java/enkan/system/repl/client/package-info.java
+++ b/enkan-repl-client/src/main/java/enkan/system/repl/client/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.system.repl.client;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-repl-client/src/main/java/enkan/system/repl/command/InitCommand.java
+++ b/enkan-repl-client/src/main/java/enkan/system/repl/command/InitCommand.java
@@ -1,6 +1,7 @@
 package enkan.system.repl.command;
 
 import enkan.system.EnkanSystem;
+import org.jspecify.annotations.Nullable;
 import enkan.system.SystemCommand;
 import enkan.system.Transport;
 import org.slf4j.Logger;
@@ -69,23 +70,23 @@ public class InitCommand implements SystemCommand {
             .build();
 
     /** LLM API configuration resolved once per {@link #execute} call from env vars or system properties. */
-    String apiUrl;
-    String apiKey;
-    String model;
+    @Nullable String apiUrl;
+    @Nullable String apiKey;
+    @Nullable String model;
 
     /**
      * Reference files fetched from GitHub, shared between planning and generation phases.
      * {@code null} means "not yet attempted"; an empty map means "fetched but everything failed"
      * (so offline runs do not re-hit the network on every prompt).
      */
-    private Map<String, String> referenceCache = null;
+    private @Nullable Map<String, String> referenceCache = null;
 
     /**
      * Cached result of {@link #loadInitReference()}. Loaded once on first use; reused
      * across the planning, generation, and fix-loop phases so classpath resources are
      * not re-read on every prompt build.
      */
-    private Map<String, String> initReferenceCache = null;
+    private @Nullable Map<String, String> initReferenceCache = null;
 
     private static final String[] FORBIDDEN_MARKERS = {
             "springframework",
@@ -148,7 +149,7 @@ public class InitCommand implements SystemCommand {
     }
 
     @Override
-    public boolean execute(EnkanSystem system, Transport transport, String... args) {
+    public boolean execute(@Nullable EnkanSystem system, Transport transport, String... args) {
         transport.sendOut(BOLD + CYAN + "\n  Enkan Project Generator" + RESET + "\n");
 
         this.apiUrl = config("ENKAN_AI_API_URL", "enkan.ai.apiUrl", DEFAULT_API_URL);
@@ -246,7 +247,7 @@ public class InitCommand implements SystemCommand {
         return "Generate a new Enkan project using AI";
     }
 
-    String reviewPlanInteractively(Transport transport, String description,
+    @Nullable String reviewPlanInteractively(Transport transport, String description,
             String projectName, String groupId, String outputDir) {
         String plan;
         try {
@@ -970,7 +971,7 @@ public class InitCommand implements SystemCommand {
     /**
      * Structured result of a Maven build step. {@link #errors} is {@code null} on success.
      */
-    record BuildResult(BuildPhase phase, String errors) {
+    record BuildResult(BuildPhase phase, @Nullable String errors) {
         boolean succeeded() { return errors == null; }
     }
 
@@ -1132,7 +1133,7 @@ public class InitCommand implements SystemCommand {
     }
 
     static String buildFixUserPrompt(BuildResult result, Path outPath) {
-        var filesToInclude = result.errors().lines()
+        var filesToInclude = java.util.Objects.requireNonNull(result.errors()).lines()
                 .map(line -> extractFileFromError(line, outPath))
                 .filter(java.util.Objects::nonNull)
                 .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
@@ -1179,7 +1180,7 @@ public class InitCommand implements SystemCommand {
      * Returns a {@link Path} contained within {@code outPath}, or {@code null} if no
      * path could be extracted or the path is outside the project root.
      */
-    static Path extractFileFromError(String errorLine, Path outPath) {
+    static @Nullable Path extractFileFromError(String errorLine, Path outPath) {
         if (!errorLine.startsWith("[ERROR]") && !errorLine.startsWith("[FATAL]")) return null;
         String body = errorLine.substring(errorLine.indexOf(']') + 1).trim();
 
@@ -1203,7 +1204,7 @@ public class InitCommand implements SystemCommand {
         return null;
     }
 
-    private static Path safeInProjectPath(String candidate, Path outPath) {
+    private static @Nullable Path safeInProjectPath(String candidate, Path outPath) {
         if (candidate == null || candidate.isBlank()) return null;
         try {
             Path p = Path.of(candidate).toAbsolutePath().normalize();
@@ -1266,7 +1267,8 @@ public class InitCommand implements SystemCommand {
      * {@code /chat/completions} is appended. A trailing slash on the base URL is tolerated.
      */
     URI resolveChatCompletionUri() {
-        String base = apiUrl.endsWith("/") ? apiUrl.substring(0, apiUrl.length() - 1) : apiUrl;
+        String url = java.util.Objects.requireNonNull(apiUrl);
+        String base = url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
         if (base.endsWith("/chat/completions")) {
             return URI.create(base);
         }
@@ -1277,7 +1279,7 @@ public class InitCommand implements SystemCommand {
             throws IOException, InterruptedException {
         if (transport != null) transport.startSpinner(spinnerLabel);
         try {
-            String requestBody = buildRequestBody(model, systemPrompt, userPrompt, true);
+            String requestBody = buildRequestBody(java.util.Objects.requireNonNull(model), systemPrompt, userPrompt, true);
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(resolveChatCompletionUri())
                     .timeout(Duration.ofMinutes(10))
@@ -1349,7 +1351,7 @@ public class InitCommand implements SystemCommand {
      *
      * @return the unescaped text, or {@code null} if the line has no text delta
      */
-    private String extractSseContent(String line) {
+    private @Nullable String extractSseContent(String line) {
         if (!line.startsWith("data: ")) return null;
         String data = line.substring(6).trim();
         if (data.equals("[DONE]")) return null;
@@ -1366,7 +1368,7 @@ public class InitCommand implements SystemCommand {
      * Extracts a JSON string value identified by {@code key} from {@code data},
      * skipping any occurrence that is actually part of {@code excludeKey}.
      */
-    String extractJsonStringField(String data, String key, String excludeKey) {
+    @Nullable String extractJsonStringField(String data, String key, @Nullable String excludeKey) {
         int searchFrom = 0;
         while (true) {
             int idx = data.indexOf(key, searchFrom);
@@ -1455,7 +1457,7 @@ public class InitCommand implements SystemCommand {
      * Extracts a relative file path from a markdown header line.
      * Handles formats like {@code ### src/main/java/Foo.java} or {@code **src/main/java/Foo.java**}.
      */
-    static String extractFilePath(String line) {
+    static @Nullable String extractFilePath(String line) {
         // ### path/to/file
         if (line.startsWith("### ")) {
             String candidate = line.substring(4).trim();
@@ -1804,7 +1806,7 @@ public class InitCommand implements SystemCommand {
      * dependency" errors later. A user who just downloaded a release build of
      * {@code enkan-repl} never sees the warning.
      */
-    String resolveEnkanVersionOrAbort(Transport transport) {
+    @Nullable String resolveEnkanVersionOrAbort(Transport transport) {
         String v = enkanVersion();
         if ("UNKNOWN".equals(v)) {
             transport.sendErr("Cannot determine Enkan version for the generated pom.xml.");

--- a/enkan-repl-client/src/main/java/enkan/system/repl/command/package-info.java
+++ b/enkan-repl-client/src/main/java/enkan/system/repl/command/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.system.repl.command;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-repl-server/pom.xml
+++ b/enkan-repl-server/pom.xml
@@ -25,6 +25,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.unit8.enkan</groupId>
             <artifactId>enkan-system</artifactId>
             <version>${enkan.version}</version>

--- a/enkan-repl-server/src/main/java/enkan/system/repl/JShellRepl.java
+++ b/enkan-repl-server/src/main/java/enkan/system/repl/JShellRepl.java
@@ -21,6 +21,8 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.jspecify.annotations.Nullable;
+
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.stream.Collectors;
@@ -232,7 +234,7 @@ public class JShellRepl implements Repl {
      * {@inheritDoc}
      */
     @Override
-    public Future<?> getBackground(String name) {
+    public @Nullable Future<?> getBackground(String name) {
         Future<?> future = backgroundTasks.get(name);
         if (future != null && (future.isCancelled() || future.isDone())) {
             backgroundTasks.remove(name);
@@ -337,7 +339,7 @@ public class JShellRepl implements Repl {
              ZMQ.Socket server = ctx.createSocket(SocketType.ROUTER);
              ZMQ.Socket completerSock = ctx.createSocket(SocketType.ROUTER)) {
             int port = Env.getInt("repl.port", 0);
-            String host = Env.getString("repl.host", "localhost");
+            String host = Objects.requireNonNull(Env.getString("repl.host", "localhost"));
             localOnly = host.equals("localhost") || host.equals("127.0.0.1") || host.equals("::1");
             if (port == 0) {
                 port = server.bindToRandomPort("tcp://" + host);
@@ -408,8 +410,8 @@ public class JShellRepl implements Repl {
 
     }
 
-    private volatile Integer lastWrittenPort = null;
-    private volatile Path lastPortFile = null;
+    private volatile @Nullable Integer lastWrittenPort = null;
+    private volatile @Nullable Path lastPortFile = null;
 
     private static Path getPortFile() {
         String override = System.getProperty("enkan.repl.portFile");

--- a/enkan-repl-server/src/main/java/enkan/system/repl/jshell/JShellIoProxy.java
+++ b/enkan-repl-server/src/main/java/enkan/system/repl/jshell/JShellIoProxy.java
@@ -189,7 +189,7 @@ public class JShellIoProxy {
                     if (line == null) break;
                     broadcast(ReplResponse.withOut(line));
                 } catch (IOException e) {
-                    broadcast(ReplResponse.withErr(e.getMessage()));
+                    broadcast(ReplResponse.withErr(e.toString()));
                     break;
                 }
             }
@@ -203,7 +203,7 @@ public class JShellIoProxy {
                     if (line == null) break;
                     broadcast(ReplResponse.withErr(line));
                 } catch (IOException e) {
-                    broadcast(ReplResponse.withErr(e.getMessage()));
+                    broadcast(ReplResponse.withErr(e.toString()));
                     break;
                 }
             }

--- a/enkan-repl-server/src/main/java/enkan/system/repl/jshell/command/ScanPackagesCommand.java
+++ b/enkan-repl-server/src/main/java/enkan/system/repl/jshell/command/ScanPackagesCommand.java
@@ -5,10 +5,14 @@ import enkan.system.ReplResponse;
 import enkan.system.SystemCommand;
 import enkan.system.Transport;
 
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
+
 public class ScanPackagesCommand implements SystemCommand {
     @Override
-    public boolean execute(EnkanSystem system, Transport transport, String... args) {
-        system.getAllComponents().forEach(
+    public boolean execute(@Nullable EnkanSystem system, Transport transport, String... args) {
+        Objects.requireNonNull(system).getAllComponents().forEach(
                 c -> transport.send(ReplResponse.withOut(c.getClass().getName()))
         );
         return true;

--- a/enkan-repl-server/src/main/java/enkan/system/repl/jshell/command/package-info.java
+++ b/enkan-repl-server/src/main/java/enkan/system/repl/jshell/command/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.system.repl.jshell.command;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-repl-server/src/main/java/enkan/system/repl/jshell/package-info.java
+++ b/enkan-repl-server/src/main/java/enkan/system/repl/jshell/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.system.repl.jshell;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-repl-server/src/main/java/enkan/system/repl/package-info.java
+++ b/enkan-repl-server/src/main/java/enkan/system/repl/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.system.repl;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-repl-server/src/main/java/enkan/system/repl/websocket/WebSocketServer.java
+++ b/enkan-repl-server/src/main/java/enkan/system/repl/websocket/WebSocketServer.java
@@ -1,5 +1,7 @@
 package enkan.system.repl.websocket;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.*;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -28,9 +30,9 @@ public class WebSocketServer implements Runnable, Closeable {
     private final int port;
     private final BiConsumer<WebSocketSession, String> messageHandler;
     private final Map<String, WebSocketSession> sessions = new ConcurrentHashMap<>();
-    private volatile ServerSocket serverSocket;
+    private volatile @Nullable ServerSocket serverSocket;
     private volatile boolean stopped;
-    private volatile Consumer<String> onDisconnect;
+    private volatile @Nullable Consumer<String> onDisconnect;
 
     /**
      * @param port           the port to listen on
@@ -163,7 +165,7 @@ public class WebSocketServer implements Runnable, Closeable {
     /**
      * Read a single line (terminated by \r\n or \n) byte-by-byte.
      */
-    private static String readLine(InputStream in) throws IOException {
+    private static @Nullable String readLine(InputStream in) throws IOException {
         ByteArrayOutputStream buf = new ByteArrayOutputStream();
         int b;
         while ((b = in.read()) != -1) {

--- a/enkan-repl-server/src/main/java/enkan/system/repl/websocket/WebSocketServerTransport.java
+++ b/enkan-repl-server/src/main/java/enkan/system/repl/websocket/WebSocketServerTransport.java
@@ -3,6 +3,8 @@ package enkan.system.repl.websocket;
 import enkan.system.ReplResponse;
 import enkan.system.Transport;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.IOException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -43,7 +45,7 @@ public class WebSocketServerTransport implements Transport {
     }
 
     @Override
-    public String recv(long timeout) {
+    public @Nullable String recv(long timeout) {
         try {
             if (timeout < 0) {
                 return incoming.take();

--- a/enkan-repl-server/src/main/java/enkan/system/repl/websocket/WebSocketSession.java
+++ b/enkan-repl-server/src/main/java/enkan/system/repl/websocket/WebSocketSession.java
@@ -1,8 +1,11 @@
 package enkan.system.repl.websocket;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.*;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 /**
  * Represents a single WebSocket connection.
@@ -48,7 +51,7 @@ public class WebSocketSession implements Closeable {
      * @return the text message, or null if the connection was closed
      * @throws IOException if an I/O error occurs
      */
-    public String readMessage() throws IOException {
+    public @Nullable String readMessage() throws IOException {
         while (!closed) {
             int firstByte = in.read();
             if (firstByte == -1) {
@@ -81,7 +84,7 @@ public class WebSocketSession implements Closeable {
             byte[] payload = readExact((int) payloadLength);
 
             if (masked) {
-                unmask(payload, maskKey);
+                unmask(payload, Objects.requireNonNull(maskKey));
             }
 
             switch (opcode) {

--- a/enkan-repl-server/src/main/java/enkan/system/repl/websocket/WebSocketTransportProvider.java
+++ b/enkan-repl-server/src/main/java/enkan/system/repl/websocket/WebSocketTransportProvider.java
@@ -3,6 +3,8 @@ package enkan.system.repl.websocket;
 import enkan.system.repl.TransportContext;
 import enkan.system.repl.TransportProvider;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -13,7 +15,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class WebSocketTransportProvider implements TransportProvider {
     private final int port;
-    private WebSocketServer wsServer;
+    private @Nullable WebSocketServer wsServer;
 
     /**
      * Create a provider with an ephemeral (auto-assigned) port.

--- a/enkan-repl-server/src/main/java/enkan/system/repl/websocket/package-info.java
+++ b/enkan-repl-server/src/main/java/enkan/system/repl/websocket/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.system.repl.websocket;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-repl/pom.xml
+++ b/enkan-repl/pom.xml
@@ -22,6 +22,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.unit8.enkan</groupId>
             <artifactId>enkan-system</artifactId>
         </dependency>

--- a/enkan-repl/src/main/java/enkan/system/repl/package-info.java
+++ b/enkan-repl/src/main/java/enkan/system/repl/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.system.repl;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-repl/src/main/java/enkan/system/repl/serdes/package-info.java
+++ b/enkan-repl/src/main/java/enkan/system/repl/serdes/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.system.repl.serdes;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-servlet/pom.xml
+++ b/enkan-servlet/pom.xml
@@ -16,6 +16,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.unit8.enkan</groupId>
             <artifactId>enkan-web</artifactId>
             <version>${enkan.version}</version>

--- a/enkan-servlet/src/main/java/enkan/servlet/util/ServletUtils.java
+++ b/enkan-servlet/src/main/java/enkan/servlet/util/ServletUtils.java
@@ -8,6 +8,8 @@ import enkan.web.data.StreamingBody;
 import enkan.exception.FalteringEnvironmentException;
 import enkan.exception.UnreachableException;
 
+import org.jspecify.annotations.Nullable;
+
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -32,7 +34,7 @@ public class ServletUtils {
         return headers;
     }
 
-    private static Long getContentLength(HttpServletRequest servletRequest) {
+    private static @Nullable Long getContentLength(HttpServletRequest servletRequest) {
         long length = servletRequest.getContentLengthLong();
         return length >= 0 ? length : null;
     }
@@ -76,7 +78,7 @@ public class ServletUtils {
         });
     }
 
-    private static void setBody(HttpServletResponse servletResponse, Object body) throws IOException {
+    private static void setBody(HttpServletResponse servletResponse, @Nullable Object body) throws IOException {
         switch (body) {
             case null -> {
                 // Do nothing

--- a/enkan-servlet/src/main/java/enkan/servlet/util/package-info.java
+++ b/enkan-servlet/src/main/java/enkan/servlet/util/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.servlet.util;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-servlet/src/main/java/module-info.java
+++ b/enkan-servlet/src/main/java/module-info.java
@@ -3,4 +3,5 @@ module enkan.servlet {
 
     requires transitive enkan.web;
     requires transitive jakarta.servlet;
+    requires transitive org.jspecify;
 }

--- a/enkan-system/pom.xml
+++ b/enkan-system/pom.xml
@@ -16,6 +16,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.unit8.enkan</groupId>
             <artifactId>enkan-core</artifactId>
             <version>${enkan.version}</version>
@@ -56,4 +60,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
 </project>

--- a/enkan-system/src/main/java/enkan/component/ApplicationComponent.java
+++ b/enkan-system/src/main/java/enkan/component/ApplicationComponent.java
@@ -6,6 +6,8 @@ import enkan.config.ApplicationFactory;
 import enkan.config.ConfigurationLoader;
 import enkan.system.inject.ComponentInjector;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.function.Function;
 
 import static enkan.util.ReflectionUtils.*;
@@ -17,18 +19,18 @@ import static enkan.util.ReflectionUtils.*;
  */
 public class ApplicationComponent<AREQ, ARES> extends SystemComponent<ApplicationComponent<AREQ, ARES>> {
     /** An application instance*/
-    private Application<AREQ, ARES> application;
+    private @Nullable Application<AREQ, ARES> application;
 
     /** An application loader */
-    private ConfigurationLoader loader;
+    private @Nullable ConfigurationLoader loader;
 
     /** A name of the application factory class */
     private final String factoryClassName;
 
-    private ClassLoader originalLoader;
+    private @Nullable ClassLoader originalLoader;
 
     /** A customizer for an application */
-    private Function<Application<AREQ,ARES>, Application<AREQ,ARES>> applicationCustomizer;
+    private @Nullable Function<Application<AREQ,ARES>, Application<AREQ,ARES>> applicationCustomizer;
 
     public ApplicationComponent(String className) {
         this.factoryClassName = className;
@@ -41,12 +43,13 @@ public class ApplicationComponent<AREQ, ARES> extends SystemComponent<Applicatio
             public void start(ApplicationComponent<AREQ, ARES> component) {
                 if (component.application == null) {
                     component.application = tryReflection(() -> {
-                        component.loader = new ConfigurationLoader(getClass().getClassLoader());
+                        ConfigurationLoader appLoader = new ConfigurationLoader(getClass().getClassLoader());
+                        component.loader = appLoader;
                         component.originalLoader = Thread.currentThread().getContextClassLoader();
-                        Thread.currentThread().setContextClassLoader(loader);
+                        Thread.currentThread().setContextClassLoader(appLoader);
                         @SuppressWarnings("unchecked")
                         Class<? extends ApplicationFactory<AREQ, ARES>> factoryClass =
-                                (Class<? extends ApplicationFactory<AREQ, ARES>>) loader.loadClass(factoryClassName);
+                                (Class<? extends ApplicationFactory<AREQ, ARES>>) appLoader.loadClass(factoryClassName);
                         ComponentInjector injector = new ComponentInjector(getAllDependencies());
                         ApplicationFactory<AREQ, ARES> factory = factoryClass.getConstructor().newInstance();
                         Application<AREQ, ARES> app = factory.create(injector);
@@ -74,11 +77,11 @@ public class ApplicationComponent<AREQ, ARES> extends SystemComponent<Applicatio
         };
     }
 
-    public Application<AREQ, ARES> getApplication() {
+    public @Nullable Application<AREQ, ARES> getApplication() {
         return application;
     }
 
-    public ConfigurationLoader getLoader() {
+    public @Nullable ConfigurationLoader getLoader() {
         return loader;
     }
 

--- a/enkan-system/src/main/java/enkan/component/DataSourceComponent.java
+++ b/enkan-system/src/main/java/enkan/component/DataSourceComponent.java
@@ -1,5 +1,7 @@
 package enkan.component;
 
+import org.jspecify.annotations.Nullable;
+
 import javax.sql.DataSource;
 
 /**
@@ -11,7 +13,7 @@ public abstract class DataSourceComponent<T extends DataSourceComponent<T>> exte
     /**
      * Gets the data source that it holds.
      *
-     * @return a DataSource
+     * @return a DataSource, or {@code null} before the component is started
      */
-    public abstract DataSource getDataSource();
+    public abstract @Nullable DataSource getDataSource();
 }

--- a/enkan-system/src/main/java/enkan/component/LocalJobExecutor.java
+++ b/enkan-system/src/main/java/enkan/component/LocalJobExecutor.java
@@ -1,6 +1,7 @@
 package enkan.component;
 
 import enkan.exception.MisconfigurationException;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +36,7 @@ public class LocalJobExecutor extends JobExecutor<LocalJobExecutor> implements H
     private String name = "enkan-job";
     private long shutdownTimeoutMs = 30_000;
 
-    private volatile ExecutorService executor;
+    private volatile @Nullable ExecutorService executor;
     private volatile boolean stopping = false;
 
     private final LongAdder submittedCount = new LongAdder();
@@ -110,20 +111,21 @@ public class LocalJobExecutor extends JobExecutor<LocalJobExecutor> implements H
 
             @Override
             public void stop(LocalJobExecutor component) {
-                if (component.executor != null) {
+                ExecutorService exec = component.executor;
+                if (exec != null) {
                     component.stopping = true;
                     try {
-                        component.executor.shutdown();
+                        exec.shutdown();
                         LOG.info("LocalJobExecutor shutting down (timeout={}ms)", component.shutdownTimeoutMs);
-                        if (!component.executor.awaitTermination(
+                        if (!exec.awaitTermination(
                                 component.shutdownTimeoutMs, TimeUnit.MILLISECONDS)) {
                             LOG.warn("Tasks did not complete within {}ms, forcing shutdown",
                                     component.shutdownTimeoutMs);
-                            component.executor.shutdownNow();
+                            exec.shutdownNow();
                         }
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
-                        component.executor.shutdownNow();
+                        exec.shutdownNow();
                     } finally {
                         component.executor = null;
                         component.stopping = false;

--- a/enkan-system/src/main/java/enkan/component/WebServerComponent.java
+++ b/enkan-system/src/main/java/enkan/component/WebServerComponent.java
@@ -4,6 +4,8 @@ import enkan.collection.OptionMap;
 import enkan.exception.MisconfigurationException;
 import enkan.exception.UnreachableException;
 
+import org.jspecify.annotations.Nullable;
+
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import java.io.File;
@@ -31,18 +33,18 @@ public abstract class WebServerComponent<T extends WebServerComponent<T>> extend
     private boolean isSsl = false;
     private int sslPort = 443;
 
-    private File keystoreFile;
-    private KeyStore keystore;
-    private String keystorePassword;
+    private @Nullable File keystoreFile;
+    private @Nullable KeyStore keystore;
+    private @Nullable String keystorePassword;
 
     // preStopDelay is used by Component.stop(), not passed to the Adapter via buildOptionMap().
     // stopTimeout is passed to the Adapter via buildOptionMap() to configure the server's drain timeout.
     private long preStopDelay = 0;
     private long stopTimeout = 30000;
 
-    private File truststoreFile;
-    private KeyStore truststore;
-    private String truststorePassword;
+    private @Nullable File truststoreFile;
+    private @Nullable KeyStore truststore;
+    private @Nullable String truststorePassword;
 
     public Integer getPort() {
         return port;
@@ -94,7 +96,7 @@ public abstract class WebServerComponent<T extends WebServerComponent<T>> extend
         }
     }
 
-    public KeyStore getKeystore() {
+    public @Nullable KeyStore getKeystore() {
         if (keystore == null && keystoreFile != null) {
             try {
                 keystore = KeyStore.getInstance("JKS");
@@ -118,7 +120,7 @@ public abstract class WebServerComponent<T extends WebServerComponent<T>> extend
         this.keystore = keystore;
     }
 
-    public String getKeystorePassword() {
+    public @Nullable String getKeystorePassword() {
         return keystorePassword;
     }
 
@@ -136,7 +138,7 @@ public abstract class WebServerComponent<T extends WebServerComponent<T>> extend
         }
     }
 
-    public KeyStore getTruststore() {
+    public @Nullable KeyStore getTruststore() {
         if (truststore == null && truststoreFile != null) {
             try {
                 truststore = KeyStore.getInstance("JKS");
@@ -161,7 +163,7 @@ public abstract class WebServerComponent<T extends WebServerComponent<T>> extend
         this.truststore = truststore;
     }
 
-    public String getTruststorePassword() {
+    public @Nullable String getTruststorePassword() {
         return truststorePassword;
     }
 

--- a/enkan-system/src/main/java/enkan/component/builtin/package-info.java
+++ b/enkan-system/src/main/java/enkan/component/builtin/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.component.builtin;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-system/src/main/java/enkan/component/package-info.java
+++ b/enkan-system/src/main/java/enkan/component/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.component;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-system/src/main/java/enkan/config/ConfigurationLoader.java
+++ b/enkan-system/src/main/java/enkan/config/ConfigurationLoader.java
@@ -3,6 +3,8 @@ package enkan.config;
 import enkan.component.SystemComponent;
 import enkan.exception.UnreachableException;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.File;
@@ -146,7 +148,7 @@ public class ConfigurationLoader extends ClassLoader {
      * without defining the class. Returns {@code null} if the bytecode
      * cannot be read.
      */
-    private String readSuperClassName(String name) {
+    private @Nullable String readSuperClassName(String name) {
         String resource = name.replace('.', '/') + ".class";
         try (InputStream raw = getResourceAsStream(resource);
              DataInputStream in = raw != null ? new DataInputStream(raw) : null) {
@@ -193,7 +195,7 @@ public class ConfigurationLoader extends ClassLoader {
         }
     }
 
-    private Class<?> defineClass(String name, boolean resolve) {
+    private @Nullable Class<?> defineClass(String name, boolean resolve) {
         try (InputStream in = getResourceAsStream(name.replaceAll("\\.", "/") + ".class");
              ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             if (in == null) return null;

--- a/enkan-system/src/main/java/enkan/config/package-info.java
+++ b/enkan-system/src/main/java/enkan/config/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.config;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-system/src/main/java/enkan/system/EnkanSystem.java
+++ b/enkan-system/src/main/java/enkan/system/EnkanSystem.java
@@ -5,6 +5,8 @@ import enkan.component.LifecycleManager;
 import enkan.component.SystemComponent;
 import enkan.exception.MisconfigurationException;
 
+import org.jspecify.annotations.Nullable;
+
 import org.crac.Context;
 import org.crac.Core;
 import org.crac.Resource;
@@ -111,7 +113,7 @@ public class EnkanSystem {
      * @return component
      */
     @SuppressWarnings("unchecked")
-    public <T extends SystemComponent<T>> T getComponent(String name) {
+    public <T extends SystemComponent<T>> @Nullable T getComponent(String name) {
         return (T) components.get(name);
     }
 
@@ -124,7 +126,7 @@ public class EnkanSystem {
      * @param componentType the class of the expected component type
      * @return the component, or {@code null}
      */
-    public <T extends SystemComponent<T>> T getComponent(String name, Class<? extends T> componentType) {
+    public <T extends SystemComponent<T>> @Nullable T getComponent(String name, Class<? extends T> componentType) {
         return components.entrySet()
                 .stream()
                 .filter(e -> e.getKey().equals(name))
@@ -266,7 +268,7 @@ public class EnkanSystem {
     public String toString() {
         String out = componentsOrder.stream()
                 .map(name -> "  \"" + name + "\": " +
-                        Arrays.stream(components.get(name).toString().split("\n"))
+                        Arrays.stream(Objects.requireNonNull(components.get(name)).toString().split("\n"))
                                 .map(line -> "  " + line)
                                 .collect(Collectors.joining("\n")))
                 .collect(Collectors.joining(",\n"));

--- a/enkan-system/src/main/java/enkan/system/Repl.java
+++ b/enkan-system/src/main/java/enkan/system/Repl.java
@@ -1,5 +1,7 @@
 package enkan.system;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.concurrent.Future;
 
 /**
@@ -28,9 +30,9 @@ public interface Repl extends Runnable {
      * Get a future object for a background task.
      *
      * @param name The name of a background task
-     * @return The future of background task
+     * @return The future of background task, or {@code null} if none is registered
      */
-    Future<?> getBackground(String name);
+    @Nullable Future<?> getBackground(String name);
 
     /**
      * Get the port number of this REPL.

--- a/enkan-system/src/main/java/enkan/system/ReplResponse.java
+++ b/enkan-system/src/main/java/enkan/system/ReplResponse.java
@@ -1,5 +1,7 @@
 package enkan.system;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.Serializable;
 import java.util.EnumSet;
 import java.util.Set;
@@ -13,11 +15,11 @@ import static enkan.system.ReplResponse.ResponseStatus.*;
 public class ReplResponse implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    private String id;
+    private @Nullable String id;
     private final EnumSet<ResponseStatus> status;
-    private String value;
-    private String out;
-    private String err;
+    private @Nullable String value;
+    private @Nullable String out;
+    private @Nullable String err;
 
     public ReplResponse() {
         status = EnumSet.noneOf(ResponseStatus.class);
@@ -50,7 +52,7 @@ public class ReplResponse implements Serializable {
         SHUTDOWN, UNKNOWN_COMMAND, ERROR, DONE, NEED_INPUT
     }
 
-    public String getId() {
+    public @Nullable String getId() {
         return id;
     }
 
@@ -58,27 +60,27 @@ public class ReplResponse implements Serializable {
         return status;
     }
 
-    public String getValue() {
+    public @Nullable String getValue() {
         return value;
     }
 
-    public void setValue(String value) {
+    public void setValue(@Nullable String value) {
         this.value = value;
     }
 
-    public String getOut() {
+    public @Nullable String getOut() {
         return out;
     }
 
-    public void setOut(String out) {
+    public void setOut(@Nullable String out) {
         this.out = out;
     }
 
-    public String getErr() {
+    public @Nullable String getErr() {
         return err;
     }
 
-    public void setErr(String err) {
+    public void setErr(@Nullable String err) {
         this.err = err;
     }
 

--- a/enkan-system/src/main/java/enkan/system/SystemCommand.java
+++ b/enkan-system/src/main/java/enkan/system/SystemCommand.java
@@ -1,5 +1,7 @@
 package enkan.system;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.Serializable;
 
 /**
@@ -11,12 +13,14 @@ public interface SystemCommand extends Serializable {
     /**
      * Execute this command.
      *
-     * @param system Enkan system
+     * @param system Enkan system, or {@code null} when the command is run
+     *               host-side as a local command (see
+     *               {@link Repl#registerLocalCommand}) with no attached system
      * @param transport A transport
      * @param args arguments
      * @return true if the command will terminate the REPL, otherwise false.
      */
-    boolean execute(EnkanSystem system, Transport transport, String... args);
+    boolean execute(@Nullable EnkanSystem system, Transport transport, String... args);
 
     /**
      * A short one-line description shown in the command list.

--- a/enkan-system/src/main/java/enkan/system/Transport.java
+++ b/enkan-system/src/main/java/enkan/system/Transport.java
@@ -2,6 +2,8 @@ package enkan.system;
 
 import enkan.system.ReplResponse.ResponseStatus;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Arrays;
 
 import static enkan.system.ReplResponse.ResponseStatus.*;
@@ -35,7 +37,7 @@ public interface Transport {
      *                indefinitely
      * @return the received message, or {@code null} on timeout
      */
-    String recv(long timeout);
+    @Nullable String recv(long timeout);
 
     /**
      * Sends a normal output message with status {@code DONE}.
@@ -77,7 +79,7 @@ public interface Transport {
      *
      * @return the received message
      */
-    default String recv() {
+    default @Nullable String recv() {
         return recv(-1);
     }
 

--- a/enkan-system/src/main/java/enkan/system/command/HelpCommand.java
+++ b/enkan-system/src/main/java/enkan/system/command/HelpCommand.java
@@ -1,6 +1,7 @@
 package enkan.system.command;
 
 import enkan.system.EnkanSystem;
+import org.jspecify.annotations.Nullable;
 import enkan.system.ReplResponse;
 import enkan.system.SystemCommand;
 import enkan.system.Transport;
@@ -34,7 +35,7 @@ public class HelpCommand implements SystemCommand {
     }
 
     @Override
-    public boolean execute(EnkanSystem system, Transport transport, String... args) {
+    public boolean execute(@Nullable EnkanSystem system, Transport transport, String... args) {
         if (args.length > 0 && !args[0].isEmpty()) {
             String name = args[0].startsWith("/") ? args[0].substring(1) : args[0];
             SystemCommand cmd = commands.get(name);

--- a/enkan-system/src/main/java/enkan/system/command/JsonRequestCommand.java
+++ b/enkan-system/src/main/java/enkan/system/command/JsonRequestCommand.java
@@ -2,6 +2,9 @@ package enkan.system.command;
 
 import enkan.component.WebServerComponent;
 import enkan.system.EnkanSystem;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
 import enkan.system.ReplResponse;
 import enkan.system.SystemCommand;
 import enkan.system.Transport;
@@ -36,7 +39,8 @@ public class JsonRequestCommand implements SystemCommand {
     }
 
     @Override
-    public boolean execute(EnkanSystem system, Transport transport, String... args) {
+    public boolean execute(@Nullable EnkanSystem system, Transport transport, String... args) {
+        Objects.requireNonNull(system);
         if (args.length < 2) {
             transport.sendErr("/jsonRequest [method] [path] [request json(optional)]", DONE);
             return true;

--- a/enkan-system/src/main/java/enkan/system/command/MiddlewareCommand.java
+++ b/enkan-system/src/main/java/enkan/system/command/MiddlewareCommand.java
@@ -7,6 +7,9 @@ import enkan.component.SystemComponent;
 import enkan.predicate.AnyPredicate;
 import enkan.predicate.NonePredicate;
 import enkan.system.EnkanSystem;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
 import enkan.system.ReplResponse;
 import enkan.system.SystemCommand;
 import enkan.system.Transport;
@@ -37,7 +40,8 @@ public class MiddlewareCommand implements SystemCommand {
     }
 
     @Override
-    public boolean execute(EnkanSystem system, Transport transport, String... args) {
+    public boolean execute(@Nullable EnkanSystem system, Transport transport, String... args) {
+        Objects.requireNonNull(system);
         if (args == null || args.length < 2) {
             transport.sendOut("middleware [appName] [list/predicate]");
             return true;

--- a/enkan-system/src/main/java/enkan/system/command/ResetCommand.java
+++ b/enkan-system/src/main/java/enkan/system/command/ResetCommand.java
@@ -1,6 +1,9 @@
 package enkan.system.command;
 
 import enkan.system.EnkanSystem;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
 import enkan.system.SystemCommand;
 import enkan.system.Transport;
 
@@ -13,7 +16,8 @@ public class ResetCommand implements SystemCommand {
     }
 
     @Override
-    public boolean execute(EnkanSystem system, Transport transport, String... args) {
+    public boolean execute(@Nullable EnkanSystem system, Transport transport, String... args) {
+        Objects.requireNonNull(system);
         system.stop();
         system.start();
         transport.sendOut("Reset server");

--- a/enkan-system/src/main/java/enkan/system/command/ShutdownCommand.java
+++ b/enkan-system/src/main/java/enkan/system/command/ShutdownCommand.java
@@ -1,6 +1,9 @@
 package enkan.system.command;
 
 import enkan.system.EnkanSystem;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
 import enkan.system.SystemCommand;
 import enkan.system.Transport;
 
@@ -15,7 +18,8 @@ public class ShutdownCommand implements SystemCommand {
     }
 
     @Override
-    public boolean execute(EnkanSystem system, Transport transport, String... args) {
+    public boolean execute(@Nullable EnkanSystem system, Transport transport, String... args) {
+        Objects.requireNonNull(system);
         system.stop();
         transport.sendOut("Shutdown server", SHUTDOWN);
         return false;

--- a/enkan-system/src/main/java/enkan/system/command/SqlCommand.java
+++ b/enkan-system/src/main/java/enkan/system/command/SqlCommand.java
@@ -2,6 +2,9 @@ package enkan.system.command;
 
 import enkan.component.DataSourceComponent;
 import enkan.system.EnkanSystem;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
 import enkan.system.ReplResponse;
 import enkan.system.SystemCommand;
 import enkan.system.Transport;
@@ -32,7 +35,8 @@ public class SqlCommand implements SystemCommand {
     }
 
     @Override
-    public boolean execute(EnkanSystem system, Transport transport, String... args) {
+    public boolean execute(@Nullable EnkanSystem system, Transport transport, String... args) {
+        Objects.requireNonNull(system);
         String sql = String.join(" ", args).trim();
         if (sql.isEmpty()) {
             transport.sendErr("/sql [SQL statement]");

--- a/enkan-system/src/main/java/enkan/system/command/SqlCommand.java
+++ b/enkan-system/src/main/java/enkan/system/command/SqlCommand.java
@@ -95,7 +95,8 @@ public class SqlCommand implements SystemCommand {
                 }
             }
         } catch (SQLException e) {
-            transport.sendErr(e.getLocalizedMessage());
+            String message = e.getLocalizedMessage();
+            transport.sendErr(message != null ? message : e.toString());
         }
         return true;
     }

--- a/enkan-system/src/main/java/enkan/system/command/StartCommand.java
+++ b/enkan-system/src/main/java/enkan/system/command/StartCommand.java
@@ -2,6 +2,9 @@ package enkan.system.command;
 
 import enkan.component.WebServerComponent;
 import enkan.system.EnkanSystem;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
 import enkan.system.SystemCommand;
 import enkan.system.Transport;
 
@@ -23,7 +26,8 @@ public class StartCommand implements SystemCommand {
     }
 
     @Override
-    public boolean execute(EnkanSystem system, Transport transport, String... args) {
+    public boolean execute(@Nullable EnkanSystem system, Transport transport, String... args) {
+        Objects.requireNonNull(system);
         system.start();
         transport.sendOut("Started server");
         if (args.length > 0) {

--- a/enkan-system/src/main/java/enkan/system/command/StatusCommand.java
+++ b/enkan-system/src/main/java/enkan/system/command/StatusCommand.java
@@ -1,6 +1,9 @@
 package enkan.system.command;
 
 import enkan.system.EnkanSystem;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
 import enkan.system.SystemCommand;
 import enkan.system.Transport;
 
@@ -13,7 +16,8 @@ public class StatusCommand implements SystemCommand {
     }
 
     @Override
-    public boolean execute(EnkanSystem system, Transport transport, String... args) {
+    public boolean execute(@Nullable EnkanSystem system, Transport transport, String... args) {
+        Objects.requireNonNull(system);
         if (system.isStarted()) {
             transport.sendOut("System is started");
         } else {

--- a/enkan-system/src/main/java/enkan/system/command/StopCommand.java
+++ b/enkan-system/src/main/java/enkan/system/command/StopCommand.java
@@ -1,6 +1,9 @@
 package enkan.system.command;
 
 import enkan.system.EnkanSystem;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
 import enkan.system.SystemCommand;
 import enkan.system.Transport;
 
@@ -13,7 +16,8 @@ public class StopCommand implements SystemCommand {
     }
 
     @Override
-    public boolean execute(EnkanSystem system, Transport transport, String... args) {
+    public boolean execute(@Nullable EnkanSystem system, Transport transport, String... args) {
+        Objects.requireNonNull(system);
         system.stop();
         transport.sendOut("Stopped server");
         return true;

--- a/enkan-system/src/main/java/enkan/system/command/package-info.java
+++ b/enkan-system/src/main/java/enkan/system/command/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.system.command;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-system/src/main/java/enkan/system/inject/ComponentInjector.java
+++ b/enkan-system/src/main/java/enkan/system/inject/ComponentInjector.java
@@ -4,6 +4,8 @@ import enkan.component.SystemComponent;
 import enkan.exception.MisconfigurationException;
 import enkan.exception.UnreachableException;
 
+import org.jspecify.annotations.Nullable;
+
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
@@ -150,7 +152,7 @@ public class ComponentInjector {
      * </ol>
      */
     @SuppressWarnings("unchecked")
-    private <T> Constructor<T> findInjectionConstructor(Class<T> clazz) {
+    private <T> @Nullable Constructor<T> findInjectionConstructor(Class<T> clazz) {
         Constructor<?>[] allConstructors = clazz.getDeclaredConstructors();
 
         Constructor<?>[] injectConstructors = Arrays.stream(allConstructors)
@@ -249,7 +251,7 @@ public class ComponentInjector {
         }
     }
 
-    private Class<?> findTypeInHierarchy(Class<?> type, String fqcn) {
+    private @Nullable Class<?> findTypeInHierarchy(@Nullable Class<?> type, String fqcn) {
         if (type == null || type == Object.class) {
             return null;
         }

--- a/enkan-system/src/main/java/enkan/system/inject/package-info.java
+++ b/enkan-system/src/main/java/enkan/system/inject/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.system.inject;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-system/src/main/java/enkan/system/package-info.java
+++ b/enkan-system/src/main/java/enkan/system/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.system;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-system/src/main/java/enkan/system/repl/package-info.java
+++ b/enkan-system/src/main/java/enkan/system/repl/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.system.repl;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-system/src/main/java/module-info.java
+++ b/enkan-system/src/main/java/module-info.java
@@ -8,6 +8,7 @@ module enkan.system {
     exports enkan.system.repl;
 
     requires transitive enkan.core;
+    requires transitive org.jspecify;
     requires transitive jakarta.inject;
     requires jakarta.annotation;
     requires jakarta.validation;

--- a/enkan-throttling/pom.xml
+++ b/enkan-throttling/pom.xml
@@ -16,6 +16,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.unit8.enkan</groupId>
             <artifactId>enkan-system</artifactId>
         </dependency>

--- a/enkan-throttling/src/main/java/enkan/middleware/throttling/ThrottlingMiddleware.java
+++ b/enkan-throttling/src/main/java/enkan/middleware/throttling/ThrottlingMiddleware.java
@@ -9,6 +9,8 @@ import enkan.throttling.Throttle;
 import enkan.web.middleware.WebMiddleware;
 import enkan.web.util.HttpResponseUtils;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -22,7 +24,7 @@ public class ThrottlingMiddleware implements WebMiddleware {
     private List<Throttle> throttles = Collections.emptyList();
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
         if (throttles.stream()
                 .anyMatch(throttle -> throttle.apply(request))) {
             return builder(HttpResponseUtils.response("Too Many Request"))

--- a/enkan-throttling/src/main/java/enkan/middleware/throttling/package-info.java
+++ b/enkan-throttling/src/main/java/enkan/middleware/throttling/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.middleware.throttling;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-throttling/src/main/java/enkan/throttling/package-info.java
+++ b/enkan-throttling/src/main/java/enkan/throttling/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.throttling;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-web/pom.xml
+++ b/enkan-web/pom.xml
@@ -45,6 +45,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.unit8.enkan</groupId>
             <artifactId>enkan-system</artifactId>
             <version>${enkan.version}</version>

--- a/enkan-web/src/main/java/enkan/web/application/WebApplication.java
+++ b/enkan-web/src/main/java/enkan/web/application/WebApplication.java
@@ -13,6 +13,8 @@ import enkan.predicate.PathPredicate;
 import enkan.util.MixinUtils;
 import enkan.util.Predicates;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -27,7 +29,7 @@ import java.util.function.Supplier;
  */
 public class WebApplication implements Application<HttpRequest, HttpResponse> {
     private final List<MiddlewareChain<?, ?, ?, ?>> middlewareStack = new LinkedList<>();
-    private volatile Supplier<HttpRequest> requestFactory;
+    private volatile @Nullable Supplier<HttpRequest> requestFactory;
 
     /** Registers a middleware for GET requests matching the given path. */
     public <REQ extends UriAvailable, RES, NREQ, NRES> void get(String path, Middleware<REQ, RES, NREQ, NRES> middleware) {
@@ -47,12 +49,12 @@ public class WebApplication implements Application<HttpRequest, HttpResponse> {
         use(PathPredicate.DELETE(path), middleware);
     }
 
-    public <REQ extends UriAvailable, RES> void use(Predicate<? super REQ> decision, String middlewareName, Endpoint<REQ, RES> endpoint) {
+    public <REQ extends UriAvailable, RES> void use(Predicate<? super REQ> decision, @Nullable String middlewareName, Endpoint<REQ, RES> endpoint) {
         use(decision, middlewareName, (Middleware<REQ, RES, REQ, RES>) endpoint);
     }
 
     @Override
-    public <REQ, RES, NREQ, NRES> void use(Predicate<? super REQ> decision, String middlewareName, Middleware<REQ, RES, NREQ, NRES> middleware) {
+    public <REQ, RES, NREQ, NRES> void use(Predicate<? super REQ> decision, @Nullable String middlewareName, Middleware<REQ, RES, NREQ, NRES> middleware) {
         MiddlewareChain<REQ, RES, NREQ, NRES> chain = new DefaultMiddlewareChain<>(decision, middlewareName, middleware);
         if (!middlewareStack.isEmpty()) {
             middlewareStack.getLast().setNext(cast(chain));
@@ -62,10 +64,10 @@ public class WebApplication implements Application<HttpRequest, HttpResponse> {
     }
 
     @Override
-    public HttpResponse handle(HttpRequest req) {
+    public @Nullable HttpResponse handle(HttpRequest req) {
         return new DefaultMiddlewareChain<> (Predicates.any(), "bootstrap", new Middleware<HttpRequest, HttpResponse, HttpRequest, HttpResponse>() {
             @Override
-            public <NNREQ, NNRES> HttpResponse handle(HttpRequest req1, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
+            public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest req1, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
                 return chain.next(req1);
             }
         }).setNext(cast(middlewareStack.getFirst())).next(req);

--- a/enkan-web/src/main/java/enkan/web/application/package-info.java
+++ b/enkan-web/src/main/java/enkan/web/application/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.web.application;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-web/src/main/java/enkan/web/collection/Headers.java
+++ b/enkan-web/src/main/java/enkan/web/collection/Headers.java
@@ -1,6 +1,9 @@
 package enkan.web.collection;
 
 import enkan.collection.Parameters;
+
+import org.jspecify.annotations.Nullable;
+
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
@@ -39,7 +42,7 @@ public class Headers extends Parameters {
         );
     }
 
-    private transient Set<String> cachedKeySet;
+    private transient @Nullable Set<String> cachedKeySet;
 
     protected Headers() {
         setCaseSensitive(false);
@@ -123,19 +126,19 @@ public class Headers extends Parameters {
     }
 
     @Override
-    public Object put(String key, Object value) {
+    public @Nullable Object put(String key, @Nullable Object value) {
         invalidateKeySetCache();
         return super.put(key, value);
     }
 
     @Override
-    public Object remove(Object key) {
+    public @Nullable Object remove(Object key) {
         invalidateKeySetCache();
         return super.remove(key);
     }
 
     @Override
-    public Object replace(String key, Object value) {
+    public @Nullable Object replace(String key, Object value) {
         invalidateKeySetCache();
         return super.replace(key, value);
     }

--- a/enkan-web/src/main/java/enkan/web/collection/package-info.java
+++ b/enkan-web/src/main/java/enkan/web/collection/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.web.collection;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-web/src/main/java/enkan/web/data/ContentNegotiable.java
+++ b/enkan-web/src/main/java/enkan/web/data/ContentNegotiable.java
@@ -2,41 +2,52 @@ package enkan.web.data;
 
 import enkan.data.Extendable;
 import jakarta.ws.rs.core.MediaType;
+
+import org.jspecify.annotations.Nullable;
+
 import java.util.Locale;
 
 /**
  * @author kawasima
  */
 public interface ContentNegotiable extends Extendable {
-    default MediaType getMediaType() {
+    default @Nullable MediaType getMediaType() {
         return getExtension("mediaType");
     }
 
-    default void setMediaType(MediaType mediaType) {
-        setExtension("mediaType", mediaType);
+    default void setMediaType(@Nullable MediaType mediaType) {
+        if (mediaType != null) {
+            setExtension("mediaType", mediaType);
+        }
     }
 
-    default Locale getLocale() {
+    default @Nullable Locale getLocale() {
         return getExtension("locale");
     }
 
-    default void setLocale(Locale locale) {
-        setExtension("locale", locale);
+    default void setLocale(@Nullable Locale locale) {
+        if (locale != null) {
+            setExtension("locale", locale);
+        }
     }
 
-    default String getCharset() {
+    default @Nullable String getCharset() {
         return getExtension("charset");
     }
 
-    default void setCharset(String charset) {
-        setExtension("charset", charset);
+    default void setCharset(@Nullable String charset) {
+        if (charset != null) {
+            setExtension("charset", charset);
+        }
     }
 
-    default String getEncoding() {
+    default @Nullable String getEncoding() {
         return getExtension("encoding");
     }
 
-    default void setEncoding(String encoding) {
-        setExtension("encoding", encoding);
+    default void setEncoding(@Nullable String encoding) {
+        if (encoding != null) {
+            setExtension("encoding", encoding);
+        }
     }
 }

--- a/enkan-web/src/main/java/enkan/web/data/Cookie.java
+++ b/enkan-web/src/main/java/enkan/web/data/Cookie.java
@@ -3,6 +3,8 @@ package enkan.web.data;
 import enkan.web.util.HttpDateFormat;
 import enkan.web.util.ParsingUtils;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
@@ -32,15 +34,15 @@ public sealed class Cookie implements Serializable permits HostCookie, SecureCoo
     // and rejects values containing DQUOTE (i.e., it does not accept the quoted form).
     private static final Pattern RE_COOKIE_VALUE = Pattern.compile("[\\x21\\x23-\\x2B\\x2D-\\x3A\\x3C-\\x5B\\x5D-\\x7E]*");
 
-    private String name;
-    private String value;
-    private String domain;
-    private Integer maxAge;
-    private String path;
-    private Date expires;
+    private String name = "";
+    private @Nullable String value;
+    private @Nullable String domain;
+    private @Nullable Integer maxAge;
+    private @Nullable String path;
+    private @Nullable Date expires;
     private boolean secure;
     private boolean httpOnly;
-    private String sameSite;
+    private @Nullable String sameSite;
 
     /**
      * @deprecated Use {@link #create(String, String)}, {@link HostCookie#create(String, String)},
@@ -83,46 +85,46 @@ public sealed class Cookie implements Serializable permits HostCookie, SecureCoo
         this.name = name;
     }
 
-    public String getValue() {
+    public @Nullable String getValue() {
         return value;
     }
 
-    public void setValue(String value) {
+    public void setValue(@Nullable String value) {
         if (value != null && !RE_COOKIE_VALUE.matcher(value).matches()) {
             throw new IllegalArgumentException("Invalid cookie value");
         }
         this.value = value;
     }
 
-    public String getDomain() {
+    public @Nullable String getDomain() {
         return domain;
     }
 
-    public void setDomain(String domain) {
+    public void setDomain(@Nullable String domain) {
         this.domain = domain;
     }
 
-    public Integer getMaxAge() {
+    public @Nullable Integer getMaxAge() {
         return maxAge;
     }
 
-    public void setMaxAge(Integer maxAge) {
+    public void setMaxAge(@Nullable Integer maxAge) {
         this.maxAge = maxAge;
     }
 
-    public String getPath() {
+    public @Nullable String getPath() {
         return path;
     }
 
-    public void setPath(String path) {
+    public void setPath(@Nullable String path) {
         this.path = path;
     }
 
-    public Date getExpires() {
+    public @Nullable Date getExpires() {
         return expires;
     }
 
-    public void setExpires(Date expires) {
+    public void setExpires(@Nullable Date expires) {
         this.expires = expires;
     }
 
@@ -142,11 +144,11 @@ public sealed class Cookie implements Serializable permits HostCookie, SecureCoo
         this.httpOnly = httpOnly;
     }
 
-    public String getSameSite() {
+    public @Nullable String getSameSite() {
         return sameSite;
     }
 
-    public void setSameSite(String sameSite) {
+    public void setSameSite(@Nullable String sameSite) {
         this.sameSite = sameSite;
     }
 

--- a/enkan-web/src/main/java/enkan/web/data/DefaultConversation.java
+++ b/enkan-web/src/main/java/enkan/web/data/DefaultConversation.java
@@ -1,6 +1,9 @@
 package enkan.web.data;
 
 import jakarta.enterprise.context.Conversation;
+
+import org.jspecify.annotations.Nullable;
+
 import java.util.Objects;
 import java.util.UUID;
 
@@ -8,7 +11,7 @@ import java.util.UUID;
  * @author kawasima
  */
 public class DefaultConversation implements Conversation {
-    private String id;
+    private @Nullable String id;
     private boolean isTransient = true;
     private long timeout = -1;
 
@@ -45,7 +48,7 @@ public class DefaultConversation implements Conversation {
     }
 
     @Override
-    public String getId() {
+    public @Nullable String getId() {
         return id;
     }
 

--- a/enkan-web/src/main/java/enkan/web/data/DefaultHttpRequest.java
+++ b/enkan-web/src/main/java/enkan/web/data/DefaultHttpRequest.java
@@ -4,6 +4,8 @@ import enkan.data.Session;
 import enkan.web.collection.Headers;
 import enkan.collection.Parameters;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Locale;
@@ -11,40 +13,46 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * A default implementation for HTTP request
+ * A default implementation for HTTP request.
+ *
+ * <p>This is a mutable bean populated incrementally: the server adapter sets the
+ * transport fields and middleware fill in the rest. A field being {@code null}
+ * is meaningful — it marks state that has not been populated yet (e.g. {@code
+ * ParamsMiddleware} keys off {@code getParams() == null} to decide whether to
+ * parse). Every accessor is therefore {@code @Nullable}.
  *
  * @author kawasima
  */
 public class DefaultHttpRequest implements HttpRequest {
     private int serverPort;
-    private String serverName;
-    private String remoteAddr;
-    private String uri;
-    private String queryString;
-    private String scheme;
-    private String requestMethod;
-    private String protocol;
-    private Headers headers;
-    private String contentType;
-    private Long contentLength;
-    private String characterEncoding;
-    private InputStream body;
+    private @Nullable String serverName;
+    private @Nullable String remoteAddr;
+    private @Nullable String uri;
+    private @Nullable String queryString;
+    private @Nullable String scheme;
+    private @Nullable String requestMethod;
+    private @Nullable String protocol;
+    private @Nullable Headers headers;
+    private @Nullable String contentType;
+    private @Nullable Long contentLength;
+    private @Nullable String characterEncoding;
+    private @Nullable InputStream body;
 
-    private Parameters params;
-    private Parameters formParams;
-    private Parameters queryParams;
+    private @Nullable Parameters params;
+    private @Nullable Parameters formParams;
+    private @Nullable Parameters queryParams;
 
-    private Session session;
-    private Map<String, Cookie> cookies;
-    private Map<String, Object> extensions;
+    private @Nullable Session session;
+    private @Nullable Map<String, Cookie> cookies;
+    private @Nullable Map<String, Object> extensions;
 
     @Override
-    public String getUri() {
+    public @Nullable String getUri() {
         return uri;
     }
 
     @Override
-    public void setUri(String uri) {
+    public void setUri(@Nullable String uri) {
         this.uri = uri;
     }
 
@@ -59,164 +67,164 @@ public class DefaultHttpRequest implements HttpRequest {
     }
 
     @Override
-    public String getServerName() {
+    public @Nullable String getServerName() {
         return serverName;
     }
 
     @Override
-    public void setServerName(String serverName) {
+    public void setServerName(@Nullable String serverName) {
         this.serverName = serverName;
     }
 
     @Override
-    public String getRemoteAddr() {
+    public @Nullable String getRemoteAddr() {
         return remoteAddr;
     }
 
     @Override
-    public void setRemoteAddr(String remoteAddr) {
+    public void setRemoteAddr(@Nullable String remoteAddr) {
         this.remoteAddr = remoteAddr;
     }
 
     @Override
-    public String getQueryString() {
+    public @Nullable String getQueryString() {
         return queryString;
     }
 
     @Override
-    public void setQueryString(String queryString) {
+    public void setQueryString(@Nullable String queryString) {
         this.queryString = queryString;
     }
 
     @Override
-    public String getScheme() {
+    public @Nullable String getScheme() {
         return scheme;
     }
 
     @Override
-    public void setScheme(String scheme) {
+    public void setScheme(@Nullable String scheme) {
         this.scheme = scheme;
     }
 
     @Override
-    public String getRequestMethod() {
+    public @Nullable String getRequestMethod() {
         return requestMethod;
     }
 
     @Override
-    public void setRequestMethod(String requestMethod) {
+    public void setRequestMethod(@Nullable String requestMethod) {
         this.requestMethod = Optional.ofNullable(requestMethod)
                 .map(m -> m.toUpperCase(Locale.ENGLISH))
                 .orElse(null);
     }
 
     @Override
-    public String getProtocol() {
+    public @Nullable String getProtocol() {
         return protocol;
     }
 
     @Override
-    public void setProtocol(String protocol) {
+    public void setProtocol(@Nullable String protocol) {
         this.protocol = protocol;
     }
 
     @Override
-    public Headers getHeaders() {
+    public @Nullable Headers getHeaders() {
         return headers;
     }
 
     @Override
-    public void setHeaders(Headers headers) {
+    public void setHeaders(@Nullable Headers headers) {
         this.headers = headers;
     }
 
     @Override
-    public String getContentType() {
+    public @Nullable String getContentType() {
         return contentType;
     }
 
     @Override
-    public void setContentType(String contentType) {
+    public void setContentType(@Nullable String contentType) {
         this.contentType = contentType;
     }
 
     @Override
-    public Long getContentLength() {
+    public @Nullable Long getContentLength() {
         return contentLength;
     }
 
     @Override
-    public void setContentLength(Long contentLength) {
+    public void setContentLength(@Nullable Long contentLength) {
         this.contentLength = contentLength;
     }
 
     @Override
-    public String getCharacterEncoding() {
+    public @Nullable String getCharacterEncoding() {
         return characterEncoding;
     }
 
     @Override
-    public void setCharacterEncoding(String characterEncoding) {
+    public void setCharacterEncoding(@Nullable String characterEncoding) {
         this.characterEncoding = characterEncoding;
     }
 
     @Override
-    public InputStream getBody() {
+    public @Nullable InputStream getBody() {
         return body;
     }
 
     @Override
-    public void setBody(InputStream body) {
+    public void setBody(@Nullable InputStream body) {
         this.body = body;
     }
 
     @Override
-    public Parameters getParams() {
+    public @Nullable Parameters getParams() {
         return params;
     }
 
     @Override
-    public void setParams(Parameters params) {
+    public void setParams(@Nullable Parameters params) {
         this.params = params;
     }
 
     @Override
-    public Parameters getFormParams() {
+    public @Nullable Parameters getFormParams() {
         return formParams;
     }
 
     @Override
-    public void setFormParams(Parameters formParams) {
+    public void setFormParams(@Nullable Parameters formParams) {
         this.formParams = formParams;
     }
 
     @Override
-    public Parameters getQueryParams() {
+    public @Nullable Parameters getQueryParams() {
         return queryParams;
     }
 
     @Override
-    public void setQueryParams(Parameters queryParams) {
+    public void setQueryParams(@Nullable Parameters queryParams) {
         this.queryParams = queryParams;
     }
 
     @Override
-    public Map<String, Cookie> getCookies() {
+    public @Nullable Map<String, Cookie> getCookies() {
         return cookies;
     }
 
     @Override
-    public void setCookies(Map<String, Cookie> cookies) {
+    public void setCookies(@Nullable Map<String, Cookie> cookies) {
         this.cookies = cookies;
     }
 
     @Override
-    public Session getSession() {
+    public @Nullable Session getSession() {
         return session;
     }
 
     @Override
-    public void setSession(Session session) {
+    public void setSession(@Nullable Session session) {
         this.session = session;
     }
 
@@ -230,7 +238,7 @@ public class DefaultHttpRequest implements HttpRequest {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> T getExtension(String name) {
+    public <T> @Nullable T getExtension(String name) {
         if (extensions == null) {
             extensions = new HashMap<>();
         }

--- a/enkan-web/src/main/java/enkan/web/data/DefaultHttpRequest.java
+++ b/enkan-web/src/main/java/enkan/web/data/DefaultHttpRequest.java
@@ -229,7 +229,7 @@ public class DefaultHttpRequest implements HttpRequest {
     }
 
     @Override
-    public <T> void setExtension(String name, T extension) {
+    public <T> void setExtension(String name, @Nullable T extension) {
         if (extensions == null) {
             extensions = new HashMap<>();
         }

--- a/enkan-web/src/main/java/enkan/web/data/DefaultHttpResponse.java
+++ b/enkan-web/src/main/java/enkan/web/data/DefaultHttpResponse.java
@@ -195,7 +195,7 @@ public class DefaultHttpResponse implements HttpResponse {
     }
 
     @Override
-    public <T> void setExtension(String name, T extension) {
+    public <T> void setExtension(String name, @Nullable T extension) {
         extensions.put(name, extension);
     }
 }

--- a/enkan-web/src/main/java/enkan/web/data/DefaultHttpResponse.java
+++ b/enkan-web/src/main/java/enkan/web/data/DefaultHttpResponse.java
@@ -4,6 +4,8 @@ import enkan.data.Session;
 import enkan.web.collection.Headers;
 import enkan.collection.Multimap;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -20,11 +22,11 @@ public class DefaultHttpResponse implements HttpResponse {
     private int status;
     private Headers headers;
     private Multimap<String, Cookie> cookies;
-    private Session session;
-    private String bodyString;
-    private InputStream bodyStream;
-    private File bodyFile;
-    private StreamingBody bodyStreaming;
+    private @Nullable Session session;
+    private @Nullable String bodyString;
+    private @Nullable InputStream bodyStream;
+    private @Nullable File bodyFile;
+    private @Nullable StreamingBody bodyStreaming;
 
     private final Map<String, Object> extensions;
 
@@ -67,7 +69,7 @@ public class DefaultHttpResponse implements HttpResponse {
     }
 
     @Override
-    public Object getBody() {
+    public @Nullable Object getBody() {
         if (bodyStreaming != null) {
             return bodyStreaming;
         } else if (bodyString != null) {
@@ -126,7 +128,7 @@ public class DefaultHttpResponse implements HttpResponse {
     }
 
     @Override
-    public void setBody(String body) {
+    public void setBody(@Nullable String body) {
         this.bodyString = body;
         bodyStream = null;
         bodyFile = null;
@@ -177,18 +179,18 @@ public class DefaultHttpResponse implements HttpResponse {
     }
 
     @Override
-    public Session getSession() {
+    public @Nullable Session getSession() {
         return session;
     }
 
     @Override
-    public void setSession(Session session) {
+    public void setSession(@Nullable Session session) {
         this.session = session;
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> T getExtension(String name) {
+    public <T> @Nullable T getExtension(String name) {
         return (T) extensions.get(name);
     }
 

--- a/enkan-web/src/main/java/enkan/web/data/ForgeryDetectable.java
+++ b/enkan-web/src/main/java/enkan/web/data/ForgeryDetectable.java
@@ -2,13 +2,15 @@ package enkan.web.data;
 
 import enkan.data.Extendable;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Anti-forgery token support.
  *
  * @author kawasima
  */
 public interface ForgeryDetectable extends Extendable {
-    default String getAntiForgeryToken() {
+    default @Nullable String getAntiForgeryToken() {
         return getExtension("antiForgeryToken");
     }
 

--- a/enkan-web/src/main/java/enkan/web/data/HasBody.java
+++ b/enkan-web/src/main/java/enkan/web/data/HasBody.java
@@ -1,10 +1,12 @@
 package enkan.web.data;
 
+import org.jspecify.annotations.Nullable;
+
 public interface HasBody {
     /**
      * Returns raw body.
      *
-     * @return the raw body of this response
+     * @return the raw body of this response, or {@code null} if none is set
      */
-    Object getBody();
+    @Nullable Object getBody();
 }

--- a/enkan-web/src/main/java/enkan/web/data/HostCookie.java
+++ b/enkan-web/src/main/java/enkan/web/data/HostCookie.java
@@ -1,5 +1,7 @@
 package enkan.web.data;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * A cookie with the {@code __Host-} prefix (RFC 6265bis §4.1.3.2).
  *
@@ -67,7 +69,7 @@ public final class HostCookie extends Cookie {
      * @throws UnsupportedOperationException if {@code domain} is not {@code null}
      */
     @Override
-    public void setDomain(String domain) {
+    public void setDomain(@Nullable String domain) {
         if (domain != null) {
             throw new UnsupportedOperationException("__Host- cookies must not have a Domain attribute");
         }
@@ -93,7 +95,7 @@ public final class HostCookie extends Cookie {
      * @throws IllegalArgumentException if {@code path} is not {@code "/"}
      */
     @Override
-    public void setPath(String path) {
+    public void setPath(@Nullable String path) {
         if (path == null || !"/".equals(path)) {
             throw new IllegalArgumentException("__Host- cookies must have Path=/");
         }

--- a/enkan-web/src/main/java/enkan/web/data/HttpRequest.java
+++ b/enkan-web/src/main/java/enkan/web/data/HttpRequest.java
@@ -149,7 +149,7 @@ public interface HttpRequest
      * @param extension the extension object
      * @param <T>       the extension type
      */
-    <T> void setExtension(String name, T extension);
+    <T> void setExtension(String name, @Nullable T extension);
 
     /**
      * Retrieves an extension object previously attached to this request.

--- a/enkan-web/src/main/java/enkan/web/data/HttpRequest.java
+++ b/enkan-web/src/main/java/enkan/web/data/HttpRequest.java
@@ -9,6 +9,8 @@ import enkan.data.UriAvailable;
 import enkan.web.collection.Headers;
 import enkan.collection.Parameters;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.InputStream;
 import java.util.Map;
 
@@ -45,100 +47,100 @@ public interface HttpRequest
     void setServerPort(int serverPort);
 
     /** Returns the host name of the server that received the request. */
-    String getServerName();
+    @Nullable String getServerName();
 
     /** Sets the host name of the server that received the request. */
-    void setServerName(String serverName);
+    void setServerName(@Nullable String serverName);
 
     /** Returns the IP address of the client that sent the request. */
-    String getRemoteAddr();
+    @Nullable String getRemoteAddr();
 
     /** Sets the IP address of the client that sent the request. */
-    void setRemoteAddr(String remoteAddr);
+    void setRemoteAddr(@Nullable String remoteAddr);
 
-    /** Returns the request URI (path portion, without the query string). */
-    String getUri();
+    /** Returns the request URI (path portion, without the query string), or {@code null} until set. */
+    @Nullable String getUri();
 
     /** Sets the request URI. */
-    void setUri(String uri);
+    void setUri(@Nullable String uri);
 
     /** Returns the query string portion of the request URL, or {@code null} if none. */
-    String getQueryString();
+    @Nullable String getQueryString();
 
     /** Sets the query string portion of the request URL. */
-    void setQueryString(String queryString);
+    void setQueryString(@Nullable String queryString);
 
     /** Returns the scheme (e.g. {@code "http"} or {@code "https"}) of the request. */
-    String getScheme();
+    @Nullable String getScheme();
 
     /** Sets the scheme of the request. */
-    void setScheme(String scheme);
+    void setScheme(@Nullable String scheme);
 
-    /** Returns the HTTP method (e.g. {@code "GET"}, {@code "POST"}) of the request. */
-    String getRequestMethod();
+    /** Returns the HTTP method (e.g. {@code "GET"}, {@code "POST"}) of the request, or {@code null} until set. */
+    @Nullable String getRequestMethod();
 
     /** Sets the HTTP method of the request. */
-    void setRequestMethod(String requestMethod);
+    void setRequestMethod(@Nullable String requestMethod);
 
     /** Returns the protocol and version (e.g. {@code "HTTP/1.1"}) of the request. */
-    String getProtocol();
+    @Nullable String getProtocol();
 
     /** Sets the protocol and version of the request. */
-    void setProtocol(String protocol);
+    void setProtocol(@Nullable String protocol);
 
     /** Returns the HTTP headers associated with this request. */
-    Headers getHeaders();
+    @Nullable Headers getHeaders();
 
     /** Sets the HTTP headers for this request. */
-    void setHeaders(Headers headers);
+    void setHeaders(@Nullable Headers headers);
 
     /** Returns the MIME type of the request body, or {@code null} if not specified. */
-    String getContentType();
+    @Nullable String getContentType();
 
     /** Sets the MIME type of the request body. */
-    void setContentType(String contentType);
+    void setContentType(@Nullable String contentType);
 
     /** Returns the length of the request body in bytes, or {@code null} if unknown. */
-    Long getContentLength();
+    @Nullable Long getContentLength();
 
     /** Sets the length of the request body in bytes. */
-    void setContentLength(Long contentLength);
+    void setContentLength(@Nullable Long contentLength);
 
     /** Returns the character encoding of the request body, or {@code null} if not specified. */
-    String getCharacterEncoding();
+    @Nullable String getCharacterEncoding();
 
     /** Sets the character encoding of the request body. */
-    void setCharacterEncoding(String characterEncoding);
+    void setCharacterEncoding(@Nullable String characterEncoding);
 
-    /** Returns the request body as an {@link InputStream}. */
-    InputStream getBody();
+    /** Returns the request body as an {@link InputStream}, or {@code null} if absent. */
+    @Nullable InputStream getBody();
 
     /** Sets the request body. */
-    void setBody(InputStream body);
+    void setBody(@Nullable InputStream body);
 
-    /** Returns the merged request parameters (query + form + path). */
-    Parameters getParams();
+    /** Returns the merged request parameters (query + form + path), or {@code null} until parsed. */
+    @Nullable Parameters getParams();
 
     /** Sets the merged request parameters. */
-    void setParams(Parameters params);
+    void setParams(@Nullable Parameters params);
 
-    /** Returns the form (POST body) parameters. */
-    Parameters getFormParams();
+    /** Returns the form (POST body) parameters, or {@code null} until parsed. */
+    @Nullable Parameters getFormParams();
 
     /** Sets the form parameters. */
-    void setFormParams(Parameters formParams);
+    void setFormParams(@Nullable Parameters formParams);
 
-    /** Returns the query string parameters. */
-    Parameters getQueryParams();
+    /** Returns the query string parameters, or {@code null} until parsed. */
+    @Nullable Parameters getQueryParams();
 
     /** Sets the query string parameters. */
-    void setQueryParams(Parameters queryParams);
+    void setQueryParams(@Nullable Parameters queryParams);
 
-    /** Returns the cookies sent with this request, keyed by cookie name. */
-    Map<String, Cookie> getCookies();
+    /** Returns the cookies sent with this request keyed by cookie name, or {@code null} until parsed. */
+    @Nullable Map<String, Cookie> getCookies();
 
     /** Sets the cookies for this request. */
-    void setCookies(Map<String, Cookie> cookies);
+    void setCookies(@Nullable Map<String, Cookie> cookies);
 
     /**
      * Attaches an arbitrary extension object to this request.
@@ -156,5 +158,5 @@ public interface HttpRequest
      * @param <T>  the expected extension type
      * @return the extension object, or {@code null} if not present
      */
-    <T> T getExtension(String name);
+    <T> @Nullable T getExtension(String name);
 }

--- a/enkan-web/src/main/java/enkan/web/data/HttpResponse.java
+++ b/enkan-web/src/main/java/enkan/web/data/HttpResponse.java
@@ -7,6 +7,8 @@ import enkan.data.Traceable;
 import enkan.web.collection.Headers;
 import enkan.collection.Multimap;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.File;
 import java.io.InputStream;
 
@@ -107,7 +109,7 @@ public interface HttpResponse extends HasBody, HasStatus, HasHeaders,
      */
     InputStream getBodyAsStream();
 
-    void setBody(String body);
+    void setBody(@Nullable String body);
     void setBody(InputStream body);
     void setBody(File body);
     void setBody(StreamingBody body);

--- a/enkan-web/src/main/java/enkan/web/data/SseEvent.java
+++ b/enkan-web/src/main/java/enkan/web/data/SseEvent.java
@@ -1,5 +1,7 @@
 package enkan.web.data;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -24,7 +26,7 @@ import java.time.Duration;
  * @param retry the reconnection time hint (maps to the {@code retry:} field)
  * @author kawasima
  */
-public record SseEvent(String data, String event, String id, Duration retry) {
+public record SseEvent(@Nullable String data, @Nullable String event, @Nullable String id, @Nullable Duration retry) {
 
     /**
      * Validates fields according to the WHATWG SSE specification.
@@ -204,10 +206,10 @@ public record SseEvent(String data, String event, String id, Duration retry) {
     }
 
     public static class Builder {
-        private String data;
-        private String event;
-        private String id;
-        private Duration retry;
+        private @Nullable String data;
+        private @Nullable String event;
+        private @Nullable String id;
+        private @Nullable Duration retry;
 
         public Builder data(String data) {
             this.data = data;

--- a/enkan-web/src/main/java/enkan/web/data/WebSessionAvailable.java
+++ b/enkan-web/src/main/java/enkan/web/data/WebSessionAvailable.java
@@ -2,11 +2,13 @@ package enkan.web.data;
 
 import enkan.data.SessionAvailable;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * @author kawasima
  */
 public interface WebSessionAvailable extends SessionAvailable {
-    default String getSessionKey() {
+    default @Nullable String getSessionKey() {
         Object key = getExtension("session/key");
         return key != null ? key.toString() : null;
     }

--- a/enkan-web/src/main/java/enkan/web/data/package-info.java
+++ b/enkan-web/src/main/java/enkan/web/data/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.web.data;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-web/src/main/java/enkan/web/endpoint/HealthEndpoint.java
+++ b/enkan-web/src/main/java/enkan/web/endpoint/HealthEndpoint.java
@@ -90,7 +90,7 @@ public class HealthEndpoint implements Endpoint<HttpRequest, HttpResponse> {
         HealthStatus worst = HealthStatus.UP;
         for (HealthStatus s : componentStatuses.values()) {
             HealthStatus normalized = (s == null) ? HealthStatus.DOWN : s;
-            if (SEVERITY.get(normalized) > SEVERITY.get(worst)) {
+            if (SEVERITY.getOrDefault(normalized, 0) > SEVERITY.getOrDefault(worst, 0)) {
                 worst = normalized;
             }
         }

--- a/enkan-web/src/main/java/enkan/web/endpoint/ResourceEndpoint.java
+++ b/enkan-web/src/main/java/enkan/web/endpoint/ResourceEndpoint.java
@@ -1,6 +1,7 @@
 package enkan.web.endpoint;
 
 import enkan.Endpoint;
+import org.jspecify.annotations.Nullable;
 import enkan.collection.OptionMap;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
@@ -17,7 +18,7 @@ public class ResourceEndpoint implements Endpoint<HttpRequest, HttpResponse> {
     }
 
     @Override
-    public HttpResponse handle(HttpRequest request) {
+    public @Nullable HttpResponse handle(HttpRequest request) {
         return HttpResponseUtils.resourceResponse(path, OptionMap.empty());
     }
 }

--- a/enkan-web/src/main/java/enkan/web/endpoint/package-info.java
+++ b/enkan-web/src/main/java/enkan/web/endpoint/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.web.endpoint;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-web/src/main/java/enkan/web/http/fields/digest/DigestFields.java
+++ b/enkan-web/src/main/java/enkan/web/http/fields/digest/DigestFields.java
@@ -2,6 +2,8 @@ package enkan.web.http.fields.digest;
 
 import enkan.web.http.fields.sf.*;
 
+import org.jspecify.annotations.Nullable;
+
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Comparator;
@@ -70,7 +72,7 @@ public final class DigestFields {
      * @param defaultAlgorithm the algorithm to use when the header is absent
      * @return the negotiated algorithm name, or {@code null} to omit the digest header
      */
-    public static String negotiateAlgorithm(String wantHeaderValue, String defaultAlgorithm) {
+    public static @Nullable String negotiateAlgorithm(@Nullable String wantHeaderValue, String defaultAlgorithm) {
         if (wantHeaderValue == null) return defaultAlgorithm;
         SfDictionary dict;
         try {

--- a/enkan-web/src/main/java/enkan/web/http/fields/digest/DigestFields.java
+++ b/enkan-web/src/main/java/enkan/web/http/fields/digest/DigestFields.java
@@ -72,7 +72,7 @@ public final class DigestFields {
      * @param defaultAlgorithm the algorithm to use when the header is absent
      * @return the negotiated algorithm name, or {@code null} to omit the digest header
      */
-    public static @Nullable String negotiateAlgorithm(@Nullable String wantHeaderValue, String defaultAlgorithm) {
+    public static @Nullable String negotiateAlgorithm(@Nullable String wantHeaderValue, @Nullable String defaultAlgorithm) {
         if (wantHeaderValue == null) return defaultAlgorithm;
         SfDictionary dict;
         try {

--- a/enkan-web/src/main/java/enkan/web/http/fields/digest/package-info.java
+++ b/enkan-web/src/main/java/enkan/web/http/fields/digest/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.web.http.fields.digest;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-web/src/main/java/enkan/web/http/fields/sf/SfDictionary.java
+++ b/enkan-web/src/main/java/enkan/web/http/fields/sf/SfDictionary.java
@@ -1,5 +1,7 @@
 package enkan.web.http.fields.sf;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -25,7 +27,7 @@ public record SfDictionary(Map<String, SfMember> members) {
      * @param <T>  the expected type
      * @return the member, or {@code null} if absent
      */
-    public <T extends SfMember> T get(String key, Class<T> type) {
+    public <T extends SfMember> @Nullable T get(String key, Class<T> type) {
         return type.cast(members.get(key));
     }
 

--- a/enkan-web/src/main/java/enkan/web/http/fields/sf/SfParameters.java
+++ b/enkan-web/src/main/java/enkan/web/http/fields/sf/SfParameters.java
@@ -1,5 +1,7 @@
 package enkan.web.http.fields.sf;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -23,7 +25,7 @@ public record SfParameters(Map<String, SfValue> map) {
         return map.isEmpty();
     }
 
-    public SfValue get(String key) {
+    public @Nullable SfValue get(String key) {
         return map.get(key);
     }
 

--- a/enkan-web/src/main/java/enkan/web/http/fields/sf/package-info.java
+++ b/enkan-web/src/main/java/enkan/web/http/fields/sf/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.web.http.fields.sf;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-web/src/main/java/enkan/web/jwt/JwtHeader.java
+++ b/enkan-web/src/main/java/enkan/web/jwt/JwtHeader.java
@@ -1,5 +1,7 @@
 package enkan.web.jwt;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * JWT JOSE Header per RFC 7519 §5 / RFC 7515 §4.
  *
@@ -8,13 +10,13 @@ package enkan.web.jwt;
  * @param kid the optional key identifier
  * @author kawasima
  */
-public record JwtHeader(String typ, String alg, String kid) {
+public record JwtHeader(@Nullable String typ, @Nullable String alg, @Nullable String kid) {
 
     public JwtHeader(String alg) {
         this("JWT", alg, null);
     }
 
-    public JwtHeader(String alg, String kid) {
+    public JwtHeader(String alg, @Nullable String kid) {
         this("JWT", alg, kid);
     }
 }

--- a/enkan-web/src/main/java/enkan/web/jwt/JwtProcessor.java
+++ b/enkan-web/src/main/java/enkan/web/jwt/JwtProcessor.java
@@ -6,6 +6,8 @@ import enkan.security.crypto.JcaVerifier;
 import enkan.security.crypto.Signer;
 import enkan.security.crypto.Verifier;
 
+import org.jspecify.annotations.Nullable;
+
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
@@ -65,7 +67,7 @@ public final class JwtProcessor {
     public static String sign(JwtHeader header, byte[] claimsJsonBytes, Key key) {
         // serializeHeader validates alg is present before we attempt JwsAlgorithm lookup
         byte[] headerJson = serializeHeader(header);
-        JwsAlgorithm alg = JwsAlgorithm.fromJwsName(header.alg());
+        JwsAlgorithm alg = JwsAlgorithm.fromJwsName(java.util.Objects.requireNonNull(header.alg(), "alg"));
         String encodedHeader = URL_ENCODER.encodeToString(headerJson);
         String encodedPayload = URL_ENCODER.encodeToString(claimsJsonBytes);
         byte[] signingInput = buildSigningInput(encodedHeader, encodedPayload);
@@ -84,7 +86,7 @@ public final class JwtProcessor {
      * @param verifier the cryptographic verifier
      * @return the decoded payload bytes, or {@code null} on failure
      */
-    public static byte[] verify(String token, Verifier verifier) {
+    public static byte @Nullable [] verify(@Nullable String token, Verifier verifier) {
         if (token == null) return null;
         String[] parts = token.split("\\.", 4);
         if (parts.length != 3) return null;
@@ -135,7 +137,7 @@ public final class JwtProcessor {
      * @param key   the verification key (SecretKey for HMAC, PublicKey for asymmetric)
      * @return the decoded payload bytes, or {@code null} on failure
      */
-    public static byte[] verify(String token, Key key) {
+    public static byte @Nullable [] verify(@Nullable String token, Key key) {
         JwtHeader header = decodeHeader(token);
         if (header == null || header.alg() == null) return null;
         JwsAlgorithm alg;
@@ -159,7 +161,7 @@ public final class JwtProcessor {
      * @param key               the verification key
      * @return the decoded payload bytes, or {@code null} on failure
      */
-    public static byte[] verify(String token, JwsAlgorithm expectedAlgorithm, Key key) {
+    public static byte @Nullable [] verify(@Nullable String token, JwsAlgorithm expectedAlgorithm, Key key) {
         JwtHeader header = decodeHeader(token);
         if (header == null || header.alg() == null) return null;
         if (!expectedAlgorithm.jwsName().equals(header.alg())) return null;
@@ -176,7 +178,7 @@ public final class JwtProcessor {
      * @param <T>          the payload type
      * @return the deserialized payload, or {@code null} on failure
      */
-    public static <T> T verify(String token, Key key, Function<byte[], T> deserializer) {
+    public static <T> @Nullable T verify(@Nullable String token, Key key, Function<byte[], T> deserializer) {
         byte[] payload = verify(token, key);
         if (payload == null) return null;
         return deserializer.apply(payload);
@@ -188,7 +190,7 @@ public final class JwtProcessor {
      * @param token the JWT string
      * @return the parsed header, or {@code null} if malformed
      */
-    public static JwtHeader decodeHeader(String token) {
+    public static @Nullable JwtHeader decodeHeader(@Nullable String token) {
         if (token == null) return null;
         int dot = token.indexOf('.');
         if (dot <= 0) return null;
@@ -275,7 +277,7 @@ public final class JwtProcessor {
         return new JwtHeader(typ, alg, kid);
     }
 
-    private static String extractJsonString(String json, String key) {
+    private static @Nullable String extractJsonString(String json, String key) {
         String search = "\"" + key + "\"";
         int idx = 0;
         while (true) {
@@ -390,7 +392,7 @@ public final class JwtProcessor {
         }
     }
 
-    private static Long extractJsonNumber(String json, String key) {
+    private static @Nullable Long extractJsonNumber(String json, String key) {
         String search = "\"" + key + "\"";
         int idx = 0;
         int colonIdx = -1;

--- a/enkan-web/src/main/java/enkan/web/jwt/package-info.java
+++ b/enkan-web/src/main/java/enkan/web/jwt/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.web.jwt;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-web/src/main/java/enkan/web/middleware/AbsoluteRedirectsMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/AbsoluteRedirectsMiddleware.java
@@ -4,6 +4,7 @@ import enkan.MiddlewareChain;
 import enkan.annotation.Middleware;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 import enkan.util.ThreadingUtils;
 
 import java.net.MalformedURLException;
@@ -94,9 +95,9 @@ public class AbsoluteRedirectsMiddleware implements WebMiddleware {
      * {@inheritDoc}
      */
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
         HttpResponse response = castToHttpResponse(chain.next(request));
-        if (isRedirectResponse(response)) {
+        if (response != null && isRedirectResponse(response)) {
             updateHeader(response, "location", request);
         }
         return response;

--- a/enkan-web/src/main/java/enkan/web/middleware/AntiForgeryMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/AntiForgeryMiddleware.java
@@ -7,6 +7,7 @@ import enkan.web.collection.Headers;
 import enkan.web.data.ForgeryDetectable;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 import enkan.data.Session;
 import enkan.util.MixinUtils;
 import enkan.util.ThreadingUtils;
@@ -58,7 +59,7 @@ public class AntiForgeryMiddleware implements WebMiddleware {
         }
     }
 
-    private Map<String, ?> formParams(HttpRequest request) {
+    private @Nullable Map<String, ?> formParams(HttpRequest request) {
         return request.getParams();
     }
 
@@ -81,7 +82,7 @@ public class AntiForgeryMiddleware implements WebMiddleware {
     }
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> next) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> next) {
         String token = sessionToken(request).orElseGet(this::newToken);
         if (!isGetRequest(request) && !isValidRequest(request)) {
             return builder(HttpResponse.of("<h1>Invalid anti-forgery token</h1>"))
@@ -92,7 +93,9 @@ public class AntiForgeryMiddleware implements WebMiddleware {
             request = MixinUtils.mixin(request, ForgeryDetectable.class);
             ((ForgeryDetectable) request).setAntiForgeryToken(token);
             HttpResponse response = castToHttpResponse(next.next(request));
-            putSessionToken(response, request, token);
+            if (response != null) {
+                putSessionToken(response, request, token);
+            }
             return response;
         }
     }

--- a/enkan-web/src/main/java/enkan/web/middleware/CacheControlMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/CacheControlMiddleware.java
@@ -4,6 +4,7 @@ import enkan.MiddlewareChain;
 import enkan.annotation.Middleware;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 
 import java.time.Duration;
 import java.util.regex.Pattern;
@@ -32,12 +33,12 @@ import static enkan.web.util.HttpResponseUtils.header;
  */
 @Middleware(name = "cacheControl")
 public class CacheControlMiddleware implements WebMiddleware {
-    private Pattern staticPattern;
+    private @Nullable Pattern staticPattern;
     private String staticDirective = "public, max-age=31536000, immutable";
     private String dynamicDirective = "no-cache";
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request,
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request,
             MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
         HttpResponse response = castToHttpResponse(chain.next(request));
         if (response == null) return null;

--- a/enkan-web/src/main/java/enkan/web/middleware/ConditionalMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/ConditionalMiddleware.java
@@ -4,6 +4,7 @@ import enkan.MiddlewareChain;
 import enkan.annotation.Middleware;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 import enkan.web.util.ETagUtils;
 import enkan.web.util.HttpDateFormat;
 
@@ -35,7 +36,7 @@ public class ConditionalMiddleware implements WebMiddleware {
             "etag", "date", "vary", "cache-control", "expires", "content-location");
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> next) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> next) {
         String method = request.getRequestMethod();
 
         // §13.2.1: Skip for CONNECT, OPTIONS, TRACE
@@ -44,6 +45,10 @@ public class ConditionalMiddleware implements WebMiddleware {
         }
 
         HttpResponse response = castToHttpResponse(next.next(request));
+        if (response == null) {
+            return null;
+        }
+        var reqHeaders = java.util.Objects.requireNonNull(request.getHeaders());
 
         // §13.2.1: Only evaluate for 2xx responses
         int status = response.getStatus();
@@ -62,7 +67,7 @@ public class ConditionalMiddleware implements WebMiddleware {
         }
 
         // §13.2.2 Step 1: If-Match (strong comparison)
-        String ifMatch = request.getHeaders().get("If-Match");
+        String ifMatch = reqHeaders.get("If-Match");
         if (ifMatch != null) {
             if (!ETagUtils.matchesHeader(ifMatch, etag, false)) {
                 return preconditionFailed();
@@ -72,14 +77,14 @@ public class ConditionalMiddleware implements WebMiddleware {
 
         // §13.2.2 Step 2: If-Unmodified-Since (only when no If-Match)
         if (ifMatch == null) {
-            String ifUnmodifiedSince = request.getHeaders().get("If-Unmodified-Since");
+            String ifUnmodifiedSince = reqHeaders.get("If-Unmodified-Since");
             if (isModifiedAfter(ifUnmodifiedSince, response)) {
                 return preconditionFailed();
             }
         }
 
         // §13.2.2 Step 3: If-None-Match (weak comparison)
-        String ifNoneMatch = request.getHeaders().get("If-None-Match");
+        String ifNoneMatch = reqHeaders.get("If-None-Match");
         if (ifNoneMatch != null) {
             if (ETagUtils.matchesHeader(ifNoneMatch, etag, true)) {
                 if ("GET".equals(method) || "HEAD".equals(method)) {
@@ -92,7 +97,7 @@ public class ConditionalMiddleware implements WebMiddleware {
 
         // §13.2.2 Step 4: If-Modified-Since (GET/HEAD only, no If-None-Match)
         if (ifNoneMatch == null && ("GET".equals(method) || "HEAD".equals(method))) {
-            String ifModifiedSince = request.getHeaders().get("If-Modified-Since");
+            String ifModifiedSince = reqHeaders.get("If-Modified-Since");
             if (isNotModifiedSince(ifModifiedSince, response)) {
                 return notModified(response);
             }
@@ -107,7 +112,7 @@ public class ConditionalMiddleware implements WebMiddleware {
      * Checks whether the response's Last-Modified date is after the given condition date.
      * Returns false if either date is null or unparseable.
      */
-    private boolean isModifiedAfter(String conditionDate, HttpResponse response) {
+    private boolean isModifiedAfter(@Nullable String conditionDate, HttpResponse response) {
         if (conditionDate == null) return false;
         Optional<Instant> condInstant = HttpDateFormat.parse(conditionDate);
         Optional<Instant> modInstant = parseLastModified(response);
@@ -119,7 +124,7 @@ public class ConditionalMiddleware implements WebMiddleware {
      * Checks whether the response has NOT been modified since the given condition date.
      * Returns false if either date is null or unparseable (condition is skipped per §13.1.3).
      */
-    private boolean isNotModifiedSince(String conditionDate, HttpResponse response) {
+    private boolean isNotModifiedSince(@Nullable String conditionDate, HttpResponse response) {
         if (conditionDate == null) return false;
         Optional<Instant> condInstant = HttpDateFormat.parse(conditionDate);
         Optional<Instant> modInstant = parseLastModified(response);
@@ -137,7 +142,10 @@ public class ConditionalMiddleware implements WebMiddleware {
         response.setStatus(304);
         original.getHeaders().keySet().forEach(name -> {
             if (NOT_MODIFIED_HEADERS.contains(name.toLowerCase(Locale.ROOT))) {
-                response.getHeaders().put(name, original.getHeaders().get(name));
+                Object value = original.getHeaders().get(name);
+                if (value != null) {
+                    response.getHeaders().put(name, value);
+                }
             }
         });
         response.setBody((String) null);

--- a/enkan-web/src/main/java/enkan/web/middleware/ContentNegotiationMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/ContentNegotiationMiddleware.java
@@ -5,6 +5,7 @@ import enkan.annotation.Middleware;
 import enkan.web.data.ContentNegotiable;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 import enkan.web.middleware.negotiation.AcceptHeaderNegotiator;
 import enkan.web.middleware.negotiation.ContentNegotiator;
 import enkan.web.collection.Headers;
@@ -27,8 +28,8 @@ public class ContentNegotiationMiddleware implements WebMiddleware {
     private ContentNegotiator negotiator;
     private Set<String> allowedTypes;
     private Set<String> allowedLanguages;
-    private Set<String> allowedCharsets;
-    private Set<String> allowedEncodings;
+    private @Nullable Set<String> allowedCharsets;
+    private @Nullable Set<String> allowedEncodings;
 
     public ContentNegotiationMiddleware() {
         negotiator = new AcceptHeaderNegotiator();
@@ -37,7 +38,7 @@ public class ContentNegotiationMiddleware implements WebMiddleware {
     }
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
         Headers headers = request.getHeaders();
         String accept = headers != null ? Objects.toString(headers.getOrDefault("Accept", "*/*"), "*/*") : "*/*";
         MediaType mediaType = negotiator.bestAllowedContentType(accept, allowedTypes);

--- a/enkan-web/src/main/java/enkan/web/middleware/ContentTypeMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/ContentTypeMiddleware.java
@@ -4,6 +4,7 @@ import enkan.MiddlewareChain;
 import enkan.annotation.Middleware;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 import enkan.web.util.HttpResponseUtils;
 import enkan.util.MimeTypeUtils;
 
@@ -18,7 +19,7 @@ public class ContentTypeMiddleware implements WebMiddleware {
         if (HttpResponseUtils.getHeader(response, "Content-Type") == null) {
             String uri = request.getUri();
 
-            String type = MimeTypeUtils.extMimeType(uri);
+            String type = uri != null ? MimeTypeUtils.extMimeType(uri) : null;
             if (type == null) {
                 type = response.getBody() instanceof String ? "text/plain" : "application/octet-stream";
             }
@@ -27,7 +28,7 @@ public class ContentTypeMiddleware implements WebMiddleware {
     }
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
         HttpResponse response = castToHttpResponse(chain.next(request));
         if (response != null) {
             contentTypeResponse(response, request);

--- a/enkan-web/src/main/java/enkan/web/middleware/ConversationMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/ConversationMiddleware.java
@@ -8,6 +8,7 @@ import enkan.data.ConversationState;
 import enkan.web.data.DefaultConversation;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 import enkan.web.middleware.session.KeyValueStore;
 import enkan.web.middleware.session.MemoryStore;
 
@@ -58,7 +59,7 @@ public class ConversationMiddleware implements WebMiddleware {
         return "GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method) || "OPTIONS".equalsIgnoreCase(method);
     }
 
-    private ConversationToken parseToken(String token) {
+    private ConversationToken parseToken(@Nullable String token) {
         if (token == null) {
             return new ConversationToken(null, "invalid", "0");
         }
@@ -72,7 +73,7 @@ public class ConversationMiddleware implements WebMiddleware {
     }
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
         ConversationToken token = parseToken(readTokenFunc.apply(request));
 
         if (!isGetRequest(request) && !token.isValid()) {
@@ -88,7 +89,9 @@ public class ConversationMiddleware implements WebMiddleware {
         } else {
             conversation = new DefaultConversation(token.id);
             ConversationState state = (ConversationState) store.read(token.id);
-            request.setConversationState(state);
+            if (state != null) {
+                request.setConversationState(state);
+            }
         }
         request.setConversation(conversation);
 
@@ -97,18 +100,18 @@ public class ConversationMiddleware implements WebMiddleware {
             if (conversation.getId() != null) {
                 store.delete(conversation.getId());
             }
-        } else if (response.getConversationState() != null) {
+        } else if (response != null && response.getConversationState() != null) {
             store.write(conversation.getId(), response.getConversationState());
         }
         return response;
     }
 
     private class ConversationToken {
-        private final String id;
+        private final @Nullable String id;
         private final String hash;
         private long expires;
 
-        ConversationToken(String id, String hash, String expires) {
+        ConversationToken(@Nullable String id, String hash, String expires) {
             this.id = id;
             this.hash = hash;
             try {

--- a/enkan-web/src/main/java/enkan/web/middleware/CookiesMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/CookiesMiddleware.java
@@ -7,6 +7,7 @@ import enkan.web.data.Cookie;
 import enkan.web.data.HostCookie;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 import enkan.web.data.SecureCookie;
 
 import java.util.HashMap;
@@ -49,7 +50,8 @@ public class CookiesMiddleware implements WebMiddleware {
      * @return a map of parsed cookies; empty if the header is absent
      */
     protected Map<String, Cookie> parseCookies(HttpRequest request) {
-        String cookieHeader = request.getHeaders().get("cookie");
+        var reqHeaders = request.getHeaders();
+        String cookieHeader = reqHeaders != null ? reqHeaders.get("cookie") : null;
         if (cookieHeader == null) {
             return Map.of();
         }
@@ -105,7 +107,7 @@ public class CookiesMiddleware implements WebMiddleware {
     }
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> next) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> next) {
         cookiesRequest(request);
         HttpResponse response = castToHttpResponse(next.next(request));
         if (response != null) {

--- a/enkan-web/src/main/java/enkan/web/middleware/CorsMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/CorsMiddleware.java
@@ -7,6 +7,8 @@ import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
 import enkan.exception.MisconfigurationException;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
@@ -42,7 +44,7 @@ public class CorsMiddleware implements WebMiddleware {
 
     /** {@inheritDoc} Applies CORS headers to the response based on the request Origin. */
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
         if (credentials && isAnyOriginAllowed() && misconfigurationWarned.compareAndSet(false, true)) {
             LOG.warning("CorsMiddleware: credentials=true with origins=[\"*\"] is invalid per CORS spec. " +
                     "Browsers will reject such responses. Set explicit allowed origins instead.");
@@ -85,7 +87,7 @@ public class CorsMiddleware implements WebMiddleware {
 
         HttpResponse response = castToHttpResponse(chain.next(request));
 
-        if (isCORSRequest(request)) {
+        if (response != null && isCORSRequest(request)) {
             String requestOrigin = some(request.getHeaders(), h -> h.get("origin")).orElse(null);
             if (isAnyOriginAllowed()) {
                 header(response, "Access-Control-Allow-Origin", "*");
@@ -103,8 +105,9 @@ public class CorsMiddleware implements WebMiddleware {
     }
 
     private HttpResponse invalidCors(HttpRequest request) {
+        String origin = some(request.getHeaders(), h -> h.get("origin")).orElse(null);
         return builder(HttpResponse.of("Invalid CORS request; Origin="
-                + request.getHeaders().get("origin")
+                + origin
                 + ", Method="
                 + request.getRequestMethod()))
                 .set(HttpResponse::setHeaders, Headers.of("Content-Type", "text/plain"))
@@ -129,12 +132,15 @@ public class CorsMiddleware implements WebMiddleware {
     }
 
     private boolean isPreflightRequest(HttpRequest httpRequest) {
-        return Objects.equals(httpRequest.getRequestMethod().toUpperCase(Locale.ENGLISH), "OPTIONS")
-                && httpRequest.getHeaders().containsKey("Access-Control-Request-Method");
+        String method = httpRequest.getRequestMethod();
+        Headers reqHeaders = httpRequest.getHeaders();
+        return method != null && Objects.equals(method.toUpperCase(Locale.ENGLISH), "OPTIONS")
+                && reqHeaders != null && reqHeaders.containsKey("Access-Control-Request-Method");
     }
 
     private boolean isCORSRequest(HttpRequest httpRequest) {
-        return Objects.nonNull(httpRequest.getHeaders().get("Origin"));
+        Headers reqHeaders = httpRequest.getHeaders();
+        return reqHeaders != null && Objects.nonNull(reqHeaders.get("Origin"));
     }
 
     /**

--- a/enkan-web/src/main/java/enkan/web/middleware/CspNonceMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/CspNonceMiddleware.java
@@ -4,6 +4,7 @@ import enkan.MiddlewareChain;
 import enkan.annotation.Middleware;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 
 import java.security.SecureRandom;
 import java.util.ArrayList;
@@ -69,7 +70,7 @@ public class CspNonceMiddleware implements WebMiddleware {
     private boolean strictDynamic = false;
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request,
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request,
             MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
         String nonce = generateNonce();
         request.setExtension(EXTENSION_KEY, nonce);

--- a/enkan-web/src/main/java/enkan/web/middleware/DefaultCharsetMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/DefaultCharsetMiddleware.java
@@ -4,6 +4,7 @@ import enkan.MiddlewareChain;
 import enkan.annotation.Middleware;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 import enkan.web.util.HttpResponseUtils;
 
 import static enkan.web.util.HttpResponseUtils.getHeader;
@@ -42,14 +43,15 @@ public class DefaultCharsetMiddleware implements WebMiddleware {
 
     protected void addCharset(HttpResponse response, String charset) {
         String contentType = getHeader(response, "Content-Type");
-        if (isTextBasedContentType(contentType)
+        if (contentType != null
+                && isTextBasedContentType(contentType)
                 && !isContainsCharset(contentType)) {
             HttpResponseUtils.charset(response, charset);
         }
     }
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
         HttpResponse response = castToHttpResponse(chain.next(request));
         if (response != null) {
             addCharset(response, defaultCharset);

--- a/enkan-web/src/main/java/enkan/web/middleware/DigestValidationMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/DigestValidationMiddleware.java
@@ -4,6 +4,7 @@ import enkan.MiddlewareChain;
 import enkan.annotation.Middleware;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 import enkan.web.http.fields.digest.DigestFields;
 import enkan.web.http.fields.sf.*;
 
@@ -46,10 +47,11 @@ public class DigestValidationMiddleware implements WebMiddleware {
     }
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request,
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request,
                                               MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
-        String contentDigestHeader = request.getHeaders().get("Content-Digest");
-        String reprDigestHeader    = request.getHeaders().get("Repr-Digest");
+        var reqHeaders = request.getHeaders();
+        String contentDigestHeader = reqHeaders != null ? reqHeaders.get("Content-Digest") : null;
+        String reprDigestHeader    = reqHeaders != null ? reqHeaders.get("Repr-Digest") : null;
 
         if (contentDigestHeader == null && reprDigestHeader == null) {
             return chain.next(request);

--- a/enkan-web/src/main/java/enkan/web/middleware/FetchMetadataMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/FetchMetadataMiddleware.java
@@ -5,6 +5,7 @@ import enkan.annotation.Middleware;
 import enkan.web.collection.Headers;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Set;
 
@@ -70,7 +71,7 @@ public class FetchMetadataMiddleware implements WebMiddleware {
      * @return the HTTP response
      */
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request,
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request,
             MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
         if (!isAllowed(request)) {
             return builder(HttpResponse.of("Forbidden"))

--- a/enkan-web/src/main/java/enkan/web/middleware/FlashMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/FlashMiddleware.java
@@ -7,6 +7,7 @@ import enkan.data.FlashAvailable;
 import enkan.data.Session;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 import enkan.web.data.PersistentMarkedSession;
 import enkan.util.MixinUtils;
 
@@ -27,7 +28,10 @@ public class FlashMiddleware implements WebMiddleware {
     protected void flashRequest(HttpRequest request) {
         Session session = request.getSession();
         if (session != null && session.containsKey(flashKey)) {
-            request.setFlash((Flash<?>) session.remove(flashKey));
+            Flash<?> flash = (Flash<?>) session.remove(flashKey);
+            if (flash != null) {
+                request.setFlash(flash);
+            }
         }
     }
 
@@ -59,13 +63,15 @@ public class FlashMiddleware implements WebMiddleware {
     }
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> next) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> next) {
         request = MixinUtils.mixin(request, FlashAvailable.class);
         flashRequest(request);
 
         HttpResponse response = castToHttpResponse(next.next(request));
 
-        flashResponse(response, request);
+        if (response != null) {
+            flashResponse(response, request);
+        }
 
         return response;
     }

--- a/enkan-web/src/main/java/enkan/web/middleware/ForwardedMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/ForwardedMiddleware.java
@@ -5,6 +5,7 @@ import enkan.annotation.Middleware;
 import enkan.web.collection.Headers;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 
 import java.math.BigInteger;
 import java.net.InetAddress;
@@ -54,9 +55,10 @@ public class ForwardedMiddleware implements WebMiddleware {
     private volatile boolean preferStandard = true;
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request,
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request,
             MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
-        if (isTrustedProxy(request.getRemoteAddr())) {
+        String remoteAddr = request.getRemoteAddr();
+        if (remoteAddr != null && isTrustedProxy(remoteAddr)) {
             applyForwardedHeaders(request);
         }
         return castToHttpResponse(chain.next(request));
@@ -73,12 +75,11 @@ public class ForwardedMiddleware implements WebMiddleware {
         String xForwardedProto = joinHeader(headers, "x-forwarded-proto");
         String xForwardedHost = joinHeader(headers, "x-forwarded-host");
 
-        boolean hasStandard = forwarded != null;
         boolean hasLegacy = xForwardedFor != null || xForwardedProto != null || xForwardedHost != null;
 
         // When preferStandard=false but only Forwarded is present (no legacy headers),
         // fall back to RFC 7239 anyway rather than silently doing nothing.
-        if (hasStandard && (preferStandard || !hasLegacy)) {
+        if (forwarded != null && (preferStandard || !hasLegacy)) {
             applyRfc7239(request, forwarded);
         } else if (hasLegacy) {
             applyLegacy(request, xForwardedFor, xForwardedProto, xForwardedHost);
@@ -94,7 +95,7 @@ public class ForwardedMiddleware implements WebMiddleware {
      * (RFC 7230 §3.2.2), they are joined with {@code ", "} before parsing.
      */
     @SuppressWarnings("unchecked")
-    private static String joinHeader(Headers headers, String name) {
+    private static @Nullable String joinHeader(Headers headers, String name) {
         Object raw = headers.getRawType(name);
         if (raw == null) return null;
         if (raw instanceof List<?> list) return String.join(", ", (List<String>) list);
@@ -163,7 +164,7 @@ public class ForwardedMiddleware implements WebMiddleware {
         if (forValue != null && !forValue.isEmpty()) {
             request.setRemoteAddr(forValue);
         }
-        if ("http".equalsIgnoreCase(protoValue) || "https".equalsIgnoreCase(protoValue)) {
+        if (protoValue != null && ("http".equalsIgnoreCase(protoValue) || "https".equalsIgnoreCase(protoValue))) {
             request.setScheme(protoValue.toLowerCase(Locale.ROOT));
         }
         if (hostValue != null) {
@@ -195,7 +196,7 @@ public class ForwardedMiddleware implements WebMiddleware {
     /**
      * Applies legacy {@code X-Forwarded-*} headers to the request.
      */
-    private void applyLegacy(HttpRequest request, String xFor, String xProto, String xHost) {
+    private void applyLegacy(HttpRequest request, @Nullable String xFor, @Nullable String xProto, @Nullable String xHost) {
         if (xFor != null) {
             int commaIdx = xFor.indexOf(',');
             String firstIp = (commaIdx >= 0 ? xFor.substring(0, commaIdx) : xFor).trim();

--- a/enkan-web/src/main/java/enkan/web/middleware/IdempotencyKeyMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/IdempotencyKeyMiddleware.java
@@ -5,6 +5,7 @@ import enkan.annotation.Middleware;
 import enkan.web.collection.Headers;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 import enkan.web.middleware.idempotency.IdempotencyEntry;
 import enkan.web.middleware.session.KeyValueStore;
 import enkan.web.http.fields.sf.SfItem;
@@ -58,7 +59,7 @@ public class IdempotencyKeyMiddleware implements WebMiddleware {
     private Set<String> methods = Set.of("POST", "PATCH");
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request,
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request,
             MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
         if (store == null || !isTargetMethod(request)) {
             return castToHttpResponse(chain.next(request));
@@ -100,7 +101,7 @@ public class IdempotencyKeyMiddleware implements WebMiddleware {
         return conflictResponse();
     }
 
-    private <NNREQ, NNRES> HttpResponse executeRequest(String storeKey, HttpRequest request,
+    private <NNREQ, NNRES> @Nullable HttpResponse executeRequest(String storeKey, HttpRequest request,
             MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
         try {
             HttpResponse response = castToHttpResponse(chain.next(request));
@@ -121,8 +122,9 @@ public class IdempotencyKeyMiddleware implements WebMiddleware {
         return method != null && methods.contains(method.toUpperCase(Locale.ENGLISH));
     }
 
-    private String extractKey(HttpRequest request) {
-        String raw = request.getHeaders().get("Idempotency-Key");
+    private @Nullable String extractKey(HttpRequest request) {
+        var reqHeaders = request.getHeaders();
+        String raw = reqHeaders != null ? reqHeaders.get("Idempotency-Key") : null;
         if (raw == null || raw.isEmpty()) {
             return null;
         }

--- a/enkan-web/src/main/java/enkan/web/middleware/IdleSessionTimeoutMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/IdleSessionTimeoutMiddleware.java
@@ -5,6 +5,7 @@ import enkan.MiddlewareChain;
 import enkan.annotation.Middleware;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 import enkan.data.Session;
 import enkan.web.util.HttpResponseUtils;
 
@@ -37,7 +38,7 @@ public class IdleSessionTimeoutMiddleware implements WebMiddleware {
     }
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
         Optional<Long> endTime = some(request.getSession(),
                 session -> session.get(SESSION_KEY),
                 obj -> {
@@ -49,11 +50,14 @@ public class IdleSessionTimeoutMiddleware implements WebMiddleware {
                 });
 
         if (endTime.isPresent() && endTime.get() < currentTime()) {
-            return builder(timeoutEndpoint.handle(request))
-                    .set(HttpResponse::setSession, null)
-                    .build();
+            HttpResponse timeoutResponse = timeoutEndpoint.handle(request);
+            if (timeoutResponse != null) {
+                timeoutResponse.setSession(null);
+            }
+            return timeoutResponse;
         } else {
             HttpResponse response = castToHttpResponse(chain.next(request));
+            if (response == null) return null;
             Long nextEndTime = currentTime() + timeout;
             Session session = Optional.ofNullable(response.getSession())
                     .orElse(request.getSession());

--- a/enkan-web/src/main/java/enkan/web/middleware/MethodOverrideMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/MethodOverrideMiddleware.java
@@ -5,6 +5,8 @@ import enkan.annotation.Middleware;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -13,18 +15,21 @@ import java.util.function.Function;
  */
 @Middleware(name = "methodOverride", dependencies = {"params"})
 public class MethodOverrideMiddleware implements WebMiddleware {
-    private Function<HttpRequest, String> getterFunction = createGetter("_method");
+    private Function<HttpRequest, @Nullable String> getterFunction = createGetter("_method");
 
     public void setGetterFunction(String functionName) {
         getterFunction = createGetter(functionName);
     }
 
-    public void setGetterFunction(Function<HttpRequest, String> getterFunction) {
+    public void setGetterFunction(Function<HttpRequest, @Nullable String> getterFunction) {
         this.getterFunction = getterFunction;
     }
 
-    protected Function<HttpRequest, String> createQueryGetter(String key) {
-        return req -> req.getParams().get(key);
+    protected Function<HttpRequest, @Nullable String> createQueryGetter(String key) {
+        return req -> {
+            var params = req.getParams();
+            return params != null ? params.get(key) : null;
+        };
     }
 
     /**
@@ -33,12 +38,15 @@ public class MethodOverrideMiddleware implements WebMiddleware {
      * @param str header
      * @return A getter function
      */
-    protected Function<HttpRequest, String> createHeaderGetter(String str) {
+    protected Function<HttpRequest, @Nullable String> createHeaderGetter(String str) {
         String header = str.toLowerCase();
-        return req -> Optional.ofNullable(req.getHeaders().get(header)).orElse("");
+        return req -> {
+            var headers = req.getHeaders();
+            return headers != null ? Optional.ofNullable(headers.get(header)).orElse("") : "";
+        };
     }
 
-    protected Function<HttpRequest, String> createGetter(String str) {
+    protected Function<HttpRequest, @Nullable String> createGetter(String str) {
         if (str.substring(0, 2).equalsIgnoreCase("X-")) {
             return createHeaderGetter(str);
         }
@@ -46,7 +54,7 @@ public class MethodOverrideMiddleware implements WebMiddleware {
     }
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
         String val = getterFunction.apply(request);
         if (val != null) {
             request.setRequestMethod(val);

--- a/enkan-web/src/main/java/enkan/web/middleware/MultipartParamsMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/MultipartParamsMiddleware.java
@@ -5,6 +5,7 @@ import enkan.annotation.Middleware;
 import enkan.collection.Parameters;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 import enkan.exception.FalteringEnvironmentException;
 import enkan.exception.MisconfigurationException;
 import enkan.web.middleware.multipart.BoundedInputStream;
@@ -79,12 +80,16 @@ public class MultipartParamsMiddleware implements WebMiddleware {
             throw new MisconfigurationException("web.MULTIPART_TOO_LARGE", maxTotalSize);
         }
         InputStream body = request.getBody();
+        if (body == null) {
+            return Parameters.empty();
+        }
         if (maxTotalSize >= 0) {
             body = new BoundedInputStream(body, maxTotalSize);
         }
+        var reqHeaders = java.util.Objects.requireNonNull(request.getHeaders());
         try {
             return MultipartParser.parse(body, length,
-                    request.getHeaders().get("content-type"), 16384,
+                    reqHeaders.get("content-type"), 16384,
                     maxFileSize, maxFormFieldSize);
         } catch (BoundedInputStream.SizeLimitExceededException e) {
             throw new MisconfigurationException("web.MULTIPART_TOO_LARGE", maxTotalSize);
@@ -115,9 +120,9 @@ public class MultipartParamsMiddleware implements WebMiddleware {
      * @param <NNRES> the type of the next response object
      */
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
         Parameters multipartParams = extractMultipart(request);
-        request.getParams().putAll(multipartParams);
+        java.util.Objects.requireNonNull(request.getParams()).putAll(multipartParams);
         try {
             return castToHttpResponse(chain.next(request));
         } finally {

--- a/enkan-web/src/main/java/enkan/web/middleware/NestedParamsMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/NestedParamsMiddleware.java
@@ -5,6 +5,7 @@ import enkan.annotation.Middleware;
 import enkan.collection.Parameters;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 import enkan.exception.MisconfigurationException;
 
 import java.util.ArrayList;
@@ -191,7 +192,7 @@ public class NestedParamsMiddleware implements WebMiddleware {
     }
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
         return castToHttpResponse(chain.next(nestedParamsRequest(request, parseNestedKeys)));
     }
 }

--- a/enkan-web/src/main/java/enkan/web/middleware/NormalizationMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/NormalizationMiddleware.java
@@ -5,6 +5,7 @@ import enkan.annotation.Middleware;
 import enkan.collection.Parameters;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 import enkan.web.middleware.normalizer.Normalizer;
 
 import java.util.ArrayList;
@@ -57,7 +58,7 @@ public class NormalizationMiddleware implements WebMiddleware {
      * @return the response object
      */
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
         Parameters params = request.getParams();
         if (params != null) {
             params.keySet().forEach(key -> {

--- a/enkan-web/src/main/java/enkan/web/middleware/ParamsMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/ParamsMiddleware.java
@@ -5,6 +5,7 @@ import enkan.annotation.Middleware;
 import enkan.collection.Parameters;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 import enkan.exception.FalteringEnvironmentException;
 
 import java.io.BufferedReader;
@@ -104,7 +105,7 @@ public class ParamsMiddleware implements WebMiddleware {
     }
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest httpRequest, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> next) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest httpRequest, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> next) {
         paramsRequest(httpRequest);
         return castToHttpResponse(next.next(httpRequest));
     }

--- a/enkan-web/src/main/java/enkan/web/middleware/ResourceMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/ResourceMiddleware.java
@@ -5,6 +5,7 @@ import enkan.annotation.Middleware;
 import enkan.collection.OptionMap;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Locale;
 import java.util.Objects;
@@ -24,10 +25,14 @@ public class ResourceMiddleware implements WebMiddleware {
 
     private static final Set<String> ACCEPTABLE_METHODS = Set.of("GET", "HEAD");
 
-    protected HttpResponse resourceRequest(HttpRequest request, String rootPath) {
+    protected @Nullable HttpResponse resourceRequest(HttpRequest request, String rootPath) {
         if (ACCEPTABLE_METHODS.contains(
                 Objects.toString(request.getRequestMethod(), "").toUpperCase(Locale.ENGLISH))) {
-            String path = urlDecode(pathInfo(request)).substring(1);
+            String pathInfo = pathInfo(request);
+            if (pathInfo == null) {
+                return null;
+            }
+            String path = urlDecode(pathInfo).substring(1);
             if (!path.startsWith(uriPrefix)) {
                 return null;
             }
@@ -40,7 +45,7 @@ public class ResourceMiddleware implements WebMiddleware {
     }
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
         HttpResponse response = resourceRequest(request, rootPath);
         if (response == null) {
             response = castToHttpResponse(chain.next(request));

--- a/enkan-web/src/main/java/enkan/web/middleware/SecurityHeadersMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/SecurityHeadersMiddleware.java
@@ -4,6 +4,7 @@ import enkan.MiddlewareChain;
 import enkan.annotation.Middleware;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 
 import java.time.Duration;
 
@@ -66,9 +67,9 @@ public class SecurityHeadersMiddleware implements WebMiddleware {
     private String crossOriginResourcePolicy = "same-origin";
     private String crossOriginEmbedderPolicy = "require-corp";
     /** Disabled by default — no safe universal default exists. */
-    private String permissionsPolicy;
+    private @Nullable String permissionsPolicy;
     /** Disabled by default — endpoint URLs are deployment-specific. */
-    private String reportingEndpoints = null;
+    private @Nullable String reportingEndpoints = null;
 
     /**
      * Passes the request through the chain and applies all enabled security
@@ -79,7 +80,7 @@ public class SecurityHeadersMiddleware implements WebMiddleware {
      * @return the HTTP response with security headers applied
      */
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request,
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request,
             MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
         HttpResponse response = castToHttpResponse(chain.next(request));
         if (response == null) return null;
@@ -99,7 +100,7 @@ public class SecurityHeadersMiddleware implements WebMiddleware {
         return response;
     }
 
-    private void applyIfEnabled(HttpResponse response, String name, String value) {
+    private void applyIfEnabled(HttpResponse response, String name, @Nullable String value) {
         if (value == null) return;
         // Defense-in-depth: also checked in setters so misconfiguration is caught at startup.
         requireNoCrlf(name, value);

--- a/enkan-web/src/main/java/enkan/web/middleware/SessionMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/SessionMiddleware.java
@@ -7,6 +7,7 @@ import enkan.data.Session;
 import enkan.web.data.Cookie;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 import enkan.web.data.PersistentMarkedSession;
 import enkan.web.data.WebSessionAvailable;
 import enkan.web.middleware.session.MemoryStore;
@@ -66,10 +67,12 @@ public class SessionMiddleware implements WebMiddleware {
         some(request.getCookies(), cs -> cs.get(cookieName))
                 .ifPresent(sessionCookie -> {
                     String reqKey = sessionCookie.getValue();
-                    Session session = reqKey != null ? (Session) store.read(reqKey) : null;
-                    request.setSession(session);
-                    if (session != null) {
-                        ((WebSessionAvailable) request).setSessionKey(reqKey);
+                    if (reqKey != null) {
+                        Session session = (Session) store.read(reqKey);
+                        request.setSession(session);
+                        if (session != null) {
+                            ((WebSessionAvailable) request).setSessionKey(reqKey);
+                        }
                     }
                 });
     }
@@ -84,7 +87,7 @@ public class SessionMiddleware implements WebMiddleware {
         // Invalidate session.
         // - Call response.session == null
         // - response.session.isNew && request.session != null
-        if (session == null || (session.isNew() && request.getSession() != null)) {
+        if (sessionKey != null && (session == null || (session.isNew() && request.getSession() != null))) {
             store.delete(sessionKey);
         }
 
@@ -95,9 +98,9 @@ public class SessionMiddleware implements WebMiddleware {
                 newSessionKey = store.write(sessionKey, session);
             }
         }
-        Cookie cookie = Cookie.create(cookieName, newSessionKey != null ? newSessionKey : sessionKey);
-        populateAttrs(cookie);
         if (newSessionKey != null && !newSessionKey.equals(sessionKey)) {
+            Cookie cookie = Cookie.create(cookieName, newSessionKey);
+            populateAttrs(cookie);
             response.getCookies().put(cookieName, cookie);
         }
     }
@@ -111,11 +114,13 @@ public class SessionMiddleware implements WebMiddleware {
      * @return the HTTP response, potentially with an updated session cookie
      */
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
         request = MixinUtils.mixin(request, WebSessionAvailable.class);
         sessionRequest(request);
         HttpResponse response = castToHttpResponse(chain.next(request));
-        sessionResponse(response, request);
+        if (response != null) {
+            sessionResponse(response, request);
+        }
         return response;
     }
 

--- a/enkan-web/src/main/java/enkan/web/middleware/SignatureVerificationMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/SignatureVerificationMiddleware.java
@@ -4,6 +4,7 @@ import enkan.MiddlewareChain;
 import enkan.annotation.Middleware;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 import enkan.web.signature.*;
 import enkan.web.http.fields.sf.*;
 
@@ -37,20 +38,21 @@ public class SignatureVerificationMiddleware implements WebMiddleware {
     private Set<String> requiredComponents = Set.of();
 
     // Accept-Signature negotiation
-    private String acceptSignatureLabel;
-    private List<SignatureComponent> acceptComponents;
-    private SignatureAlgorithm acceptAlgorithm;
-    private String acceptKeyId;
+    private @Nullable String acceptSignatureLabel;
+    private @Nullable List<SignatureComponent> acceptComponents;
+    private @Nullable SignatureAlgorithm acceptAlgorithm;
+    private @Nullable String acceptKeyId;
 
     public SignatureVerificationMiddleware(SignatureKeyResolver keyResolver) {
         this.keyResolver = keyResolver;
     }
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request,
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request,
                                               MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
-        String signatureHeader = request.getHeaders().get("Signature");
-        String signatureInputHeader = request.getHeaders().get("Signature-Input");
+        var reqHeaders = java.util.Objects.requireNonNull(request.getHeaders());
+        String signatureHeader = reqHeaders.get("Signature");
+        String signatureInputHeader = reqHeaders.get("Signature-Input");
 
         if (signatureHeader == null || signatureInputHeader == null) {
             if (!requiredLabels.isEmpty() || !requiredComponents.isEmpty()) {
@@ -99,8 +101,8 @@ public class SignatureVerificationMiddleware implements WebMiddleware {
         return chain.next(request);
     }
 
-    private HttpResponse errorResponse(int status, String message) {
-        HttpResponse response = builder(HttpResponse.of(message))
+    private HttpResponse errorResponse(int status, @Nullable String message) {
+        HttpResponse response = builder(HttpResponse.of(message != null ? message : ""))
                 .set(HttpResponse::setStatus, status)
                 .build();
         if (status == 401 && acceptSignatureLabel != null) {
@@ -110,7 +112,8 @@ public class SignatureVerificationMiddleware implements WebMiddleware {
     }
 
     private String buildAcceptSignature() {
-        List<SfItem> items = acceptComponents.stream()
+        List<SignatureComponent> components = java.util.Objects.requireNonNull(acceptComponents);
+        List<SfItem> items = components.stream()
                 .map(c -> new SfItem(new SfValue.SfString(c.name()), c.parameters()))
                 .toList();
         Map<String, SfValue> paramMap = new LinkedHashMap<>();

--- a/enkan-web/src/main/java/enkan/web/middleware/TraceMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/TraceMiddleware.java
@@ -3,6 +3,7 @@ package enkan.web.middleware;
 import enkan.DecoratorMiddleware;
 import enkan.MiddlewareChain;
 import enkan.web.data.HttpResponse;
+import org.jspecify.annotations.Nullable;
 import enkan.data.TraceLog;
 import enkan.data.Traceable;
 import enkan.util.MixinUtils;
@@ -16,7 +17,7 @@ public class TraceMiddleware<REQ, RES> implements DecoratorMiddleware<REQ, RES> 
     private boolean enabled = true;
 
     @Override
-    public <NNREQ, NNRES> RES handle(REQ req, MiddlewareChain<REQ, RES, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable RES handle(REQ req, MiddlewareChain<REQ, RES, NNREQ, NNRES> chain) {
         if (req != null) {
             req = MixinUtils.mixin(req, Traceable.class);
         }

--- a/enkan-web/src/main/java/enkan/web/middleware/WebMiddleware.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/WebMiddleware.java
@@ -5,6 +5,8 @@ import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
 import enkan.exception.MisconfigurationException;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * A {@link DecoratorMiddleware} specialised for {@code HttpRequest}/{@code HttpResponse}.
  *
@@ -20,7 +22,11 @@ import enkan.exception.MisconfigurationException;
 public interface WebMiddleware extends DecoratorMiddleware<HttpRequest, HttpResponse> {
 
     /**
-     * Casts an arbitrary response object to {@link HttpResponse}.
+     * Casts the response object returned by {@code chain.next(req)} to
+     * {@link HttpResponse}.
+     *
+     * <p>A middleware may yield a {@code null} response, which is passed through
+     * unchanged. (An exhausted chain throws rather than returning {@code null}.)
      *
      * @param response the response object returned by the next middleware
      * @return the same object cast to {@link HttpResponse}, or {@code null} if
@@ -28,7 +34,7 @@ public interface WebMiddleware extends DecoratorMiddleware<HttpRequest, HttpResp
      * @throws MisconfigurationException if {@code response} is non-null but not
      *         an instance of {@link HttpResponse}
      */
-    default HttpResponse castToHttpResponse(Object response) {
+    default @Nullable HttpResponse castToHttpResponse(@Nullable Object response) {
         if (response == null) {
             return null;
         } else if (response instanceof HttpResponse httpResponse) {

--- a/enkan-web/src/main/java/enkan/web/middleware/idempotency/IdempotencyEntry.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/idempotency/IdempotencyEntry.java
@@ -3,6 +3,8 @@ package enkan.web.middleware.idempotency;
 import enkan.web.collection.Headers;
 import enkan.web.data.HttpResponse;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -16,7 +18,7 @@ import static enkan.util.BeanBuilder.builder;
  *
  * @author kawasima
  */
-public record IdempotencyEntry(State state, int status, Map<String, List<String>> headers, String body)
+public record IdempotencyEntry(State state, int status, Map<String, List<String>> headers, @Nullable String body)
         implements Serializable {
 
     public IdempotencyEntry {
@@ -64,7 +66,7 @@ public record IdempotencyEntry(State state, int status, Map<String, List<String>
     public HttpResponse toResponse() {
         Headers responseHeaders = Headers.empty();
         headers.forEach((name, values) -> values.forEach(v -> responseHeaders.put(name, v)));
-        return builder(HttpResponse.of(body))
+        return builder(HttpResponse.of(body != null ? body : ""))
                 .set(HttpResponse::setStatus, status)
                 .set(HttpResponse::setHeaders, responseHeaders)
                 .build();

--- a/enkan-web/src/main/java/enkan/web/middleware/idempotency/package-info.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/idempotency/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.web.middleware.idempotency;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-web/src/main/java/enkan/web/middleware/multipart/BufferPart.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/multipart/BufferPart.java
@@ -2,7 +2,10 @@ package enkan.web.middleware.multipart;
 
 import enkan.collection.Parameters;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.ByteArrayOutputStream;
+import java.util.Objects;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
@@ -10,14 +13,14 @@ import java.nio.charset.StandardCharsets;
  * @author kawasima
  */
 public class BufferPart extends MimePart {
-    public BufferPart(String head, String filename, String contentType, String name) {
+    public BufferPart(String head, @Nullable String filename, @Nullable String contentType, @Nullable String name) {
         super(new ByteArrayOutputStream(), head, filename, contentType, name);
     }
 
     @Override
     public Parameters getData() {
         String value = ((ByteArrayOutputStream) getBody()).toString(StandardCharsets.ISO_8859_1);
-        return Parameters.of(name, value);
+        return Parameters.of(Objects.requireNonNull(name), value);
     }
 
     @Override

--- a/enkan-web/src/main/java/enkan/web/middleware/multipart/MimePart.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/multipart/MimePart.java
@@ -2,6 +2,8 @@ package enkan.web.middleware.multipart;
 
 import enkan.collection.Parameters;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -11,11 +13,11 @@ import java.io.OutputStream;
 public abstract class MimePart {
     protected final String head;
     private final OutputStream body;
-    protected final String filename;
-    protected final String contentType;
-    protected final String name;
+    protected final @Nullable String filename;
+    protected final @Nullable String contentType;
+    protected final @Nullable String name;
 
-    public MimePart(OutputStream body, String head, String filename, String contentType, String name) {
+    public MimePart(OutputStream body, String head, @Nullable String filename, @Nullable String contentType, @Nullable String name) {
         this.head = head;
         this.body = body;
         this.filename = filename;
@@ -28,7 +30,7 @@ public abstract class MimePart {
         return body;
     }
 
-    public abstract Parameters getData();
+    public abstract @Nullable Parameters getData();
     public abstract void write(byte[] buf) throws IOException;
     public abstract void close();
 }

--- a/enkan-web/src/main/java/enkan/web/middleware/multipart/MultipartCollector.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/multipart/MultipartCollector.java
@@ -2,6 +2,8 @@ package enkan.web.middleware.multipart;
 
 import enkan.exception.MisconfigurationException;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -14,25 +16,25 @@ import java.util.stream.Stream;
  * @author kawasima
  */
 public class MultipartCollector {
-    private final BiFunction<String, String, File> tempfileFactory;
+    private final BiFunction<String, @Nullable String, File> tempfileFactory;
     private final List<MimePart> mimeParts = new ArrayList<>();
     private final List<Long> partSizes = new ArrayList<>();
     private final List<Boolean> isFile = new ArrayList<>();
     private final long maxFileSize;
     private final long maxFormFieldSize;
 
-    public MultipartCollector(BiFunction<String, String, File> tempfileFactory) {
+    public MultipartCollector(BiFunction<String, @Nullable String, File> tempfileFactory) {
         this(tempfileFactory, -1, -1);
     }
 
-    public MultipartCollector(BiFunction<String, String, File> tempfileFactory,
+    public MultipartCollector(BiFunction<String, @Nullable String, File> tempfileFactory,
                               long maxFileSize, long maxFormFieldSize) {
         this.tempfileFactory = tempfileFactory;
         this.maxFileSize = maxFileSize;
         this.maxFormFieldSize = maxFormFieldSize;
     }
 
-    public void onMimeHead(int mimeIndex, String head, String filename, String contentType, String name) throws IOException {
+    public void onMimeHead(int mimeIndex, String head, @Nullable String filename, @Nullable String contentType, @Nullable String name) throws IOException {
         if (filename != null) {
             File tempfile = tempfileFactory.apply(filename, contentType);
             mimeParts.add(new TempfilePart(tempfile, head, filename, contentType, name));

--- a/enkan-web/src/main/java/enkan/web/middleware/multipart/MultipartParser.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/multipart/MultipartParser.java
@@ -3,6 +3,8 @@ package enkan.web.middleware.multipart;
 import enkan.collection.Parameters;
 import enkan.exception.FalteringEnvironmentException;
 import enkan.web.util.CodecUtils;
+
+import org.jspecify.annotations.Nullable;
 import enkan.util.SearchUtils;
 
 import java.io.EOFException;
@@ -54,7 +56,7 @@ public class MultipartParser {
     private static final Pattern DISPPARM = Pattern.compile(String.format(";\\s*(?:%s|%s)\\s*", REGULAR_PARAMETER.pattern(), EXTENDED_PARAMETER.pattern()));
     private static final Pattern RFC2183 = Pattern.compile(String.format("^%s(%s)+$", CONDISP.pattern(), DISPPARM.pattern()), Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 
-    private static final BiFunction<String, String, File> TEMPFILE_FACTORY = (filename, contentType) -> {
+    private static final BiFunction<String, @Nullable String, File> TEMPFILE_FACTORY = (filename, contentType) -> {
         int idx = filename.indexOf('.');
         String extName = (idx >= 0 && idx < filename.length() - 1) ? filename.substring(idx) : "";
         try {
@@ -113,7 +115,12 @@ public class MultipartParser {
     public Parameters result() {
         Parameters params = Parameters.empty();
         collector.stream()
-                .forEach(part -> params.putAll(part.getData()));
+                .forEach(part -> {
+                    Parameters data = part.getData();
+                    if (data != null) {
+                        params.putAll(data);
+                    }
+                });
         return params;
     }
 
@@ -128,7 +135,7 @@ public class MultipartParser {
      * @param contentType the value of the {@code Content-Type} header
      * @return the boundary string, or {@code null} if not found or {@code contentType} is {@code null}
      */
-    public static String parseBoundary(String contentType) {
+    public static @Nullable String parseBoundary(@Nullable String contentType) {
         if (contentType == null) return null;
         // Must start with multipart/ media type.
         if (!contentType.trim().toLowerCase(java.util.Locale.ROOT).startsWith("multipart/")) return null;
@@ -176,7 +183,7 @@ public class MultipartParser {
      * @return a {@link Parameters} map of all parsed multipart parts
      * @throws IOException if an I/O error occurs while reading the stream
      */
-    public static Parameters parse(InputStream in, Long contentLength, String contentType, int bufferSize) throws IOException {
+    public static Parameters parse(InputStream in, @Nullable Long contentLength, @Nullable String contentType, int bufferSize) throws IOException {
         return parse(in, contentLength, contentType, bufferSize, -1, -1);
     }
 
@@ -192,7 +199,7 @@ public class MultipartParser {
      * @return a {@link Parameters} map of all parsed multipart parts
      * @throws IOException if an I/O error occurs while reading the stream
      */
-    public static Parameters parse(InputStream in, Long contentLength, String contentType, int bufferSize,
+    public static Parameters parse(InputStream in, @Nullable Long contentLength, @Nullable String contentType, int bufferSize,
                                    long maxFileSize, long maxFormFieldSize) throws IOException {
         if (contentLength != null && contentLength == 0) return Parameters.empty();
         String boundary = parseBoundary(contentType);
@@ -369,7 +376,7 @@ public class MultipartParser {
         }
     }
 
-    private String getFilename(String head) {
+    private @Nullable String getFilename(String head) {
         String filename = null;
         Matcher rfc2183Matcher = RFC2183.matcher(head);
         Matcher brokenQuotedMatcher = BROKEN_QUOTED.matcher(head);

--- a/enkan-web/src/main/java/enkan/web/middleware/multipart/TempfilePart.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/multipart/TempfilePart.java
@@ -2,7 +2,10 @@ package enkan.web.middleware.multipart;
 
 import enkan.collection.Parameters;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.*;
+import java.util.Objects;
 
 /**
  * @author kawasima
@@ -14,12 +17,12 @@ public class TempfilePart extends MimePart {
         return new BufferedOutputStream(new FileOutputStream(file));
     }
 
-    public TempfilePart(File tempfile, String head, String filename, String contentType, String name) throws IOException {
+    public TempfilePart(File tempfile, String head, @Nullable String filename, @Nullable String contentType, @Nullable String name) throws IOException {
         super(getOutputStream(tempfile), head, filename, contentType, name);
         this.tempfile = tempfile;
     }
 
-    private String last(String[] strArray) {
+    private @Nullable String last(String @Nullable [] strArray) {
         if (strArray == null || strArray.length == 0) {
             return null;
         } else {
@@ -28,21 +31,22 @@ public class TempfilePart extends MimePart {
     }
 
     @Override
-    public Parameters getData() {
+    public @Nullable Parameters getData() {
+        String partName = Objects.requireNonNull(name);
         if (filename != null) {
-            String fn = last(filename.split("[/\\\\]"));
-            return Parameters.of(name,
+            String fn = Objects.requireNonNull(last(filename.split("[/\\\\]")));
+            return Parameters.of(partName,
                     Parameters.of(
                             "filename", fn,
-                            "name", name,
+                            "name", partName,
                             "tempfile", tempfile,
                             "type", contentType,
                             "head", head));
         } else if (contentType != null) {
-            return Parameters.of(name,
+            return Parameters.of(partName,
                     Parameters.of(
                             "type", contentType,
-                            "name", name,
+                            "name", partName,
                             "tempfile", tempfile,
                             "head", head));
         }

--- a/enkan-web/src/main/java/enkan/web/middleware/multipart/package-info.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/multipart/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.web.middleware.multipart;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-web/src/main/java/enkan/web/middleware/negotiation/AcceptHeaderNegotiator.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/negotiation/AcceptHeaderNegotiator.java
@@ -2,6 +2,8 @@ package enkan.web.middleware.negotiation;
 
 import enkan.web.util.CodecUtils;
 
+import org.jspecify.annotations.Nullable;
+
 import jakarta.ws.rs.core.MediaType;
 import java.io.Serializable;
 import java.nio.charset.Charset;
@@ -41,7 +43,7 @@ public class AcceptHeaderNegotiator implements ContentNegotiator {
         return Double.parseDouble(qstr);
     }
 
-    public AcceptFragment<MediaType> parseMediaTypeAcceptFragment(String accept) {
+    public @Nullable AcceptFragment<MediaType> parseMediaTypeAcceptFragment(String accept) {
         String[] tokens = ACCEPT_DELIMITER.split(accept);
         if (tokens.length > 0) {
             Optional<Double> q = Arrays.stream(tokens).skip(1)
@@ -56,7 +58,7 @@ public class AcceptHeaderNegotiator implements ContentNegotiator {
         return null;
     }
 
-    public AcceptFragment<String> parseStringAcceptFragment(String accept) {
+    public @Nullable AcceptFragment<String> parseStringAcceptFragment(String accept) {
         String[] tokens = ACCEPT_DELIMITER.split(accept);
         if (tokens.length > 0) {
             Optional<Double> q = Arrays.stream(tokens).skip(1)
@@ -95,7 +97,7 @@ public class AcceptHeaderNegotiator implements ContentNegotiator {
     }
 
     @Override
-    public MediaType bestAllowedContentType(String acceptsHeader, Set<String> allowedTypes) {
+    public @Nullable MediaType bestAllowedContentType(String acceptsHeader, Set<String> allowedTypes) {
         String cacheKey = stableCacheKey(acceptsHeader, allowedTypes);
         return contentTypeCache.computeIfAbsent(cacheKey, k -> {
             Function<AcceptFragment<MediaType>, AcceptFragment<MediaType>> serverWeightFunc = createServerWeightFunc(allowedTypes.stream()
@@ -112,7 +114,7 @@ public class AcceptHeaderNegotiator implements ContentNegotiator {
     }
 
     @Override
-    public String bestAllowedCharset(String acceptsHeader, Set<String> available) {
+    public @Nullable String bestAllowedCharset(String acceptsHeader, Set<String> available) {
         String cacheKey = stableCacheKey(acceptsHeader, available);
         return charsetCache.computeIfAbsent(cacheKey, k -> {
             // Lowercase accept keys for case-insensitive matching (RFC 9110 §12.5.3)
@@ -157,7 +159,7 @@ public class AcceptHeaderNegotiator implements ContentNegotiator {
     }
 
     @Override
-    public String bestAllowedEncoding(String acceptsHeader, Set<String> available) {
+    public @Nullable String bestAllowedEncoding(String acceptsHeader, Set<String> available) {
         Map<String, Double> accepts = Arrays
                 .stream(ACCEPTS_DELIMITER.split(acceptsHeader))
                 .map(this::parseStringAcceptFragment)
@@ -185,7 +187,7 @@ public class AcceptHeaderNegotiator implements ContentNegotiator {
     }
 
     @Override
-    public String bestAllowedLanguage(String acceptsHeader, Set<String> available) {
+    public @Nullable String bestAllowedLanguage(String acceptsHeader, Set<String> available) {
         String cacheKey = stableCacheKey(acceptsHeader, available);
         return languageCache.computeIfAbsent(cacheKey, k -> {
             Map<String, Double> accepts = Arrays

--- a/enkan-web/src/main/java/enkan/web/middleware/negotiation/ContentNegotiator.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/negotiation/ContentNegotiator.java
@@ -1,5 +1,7 @@
 package enkan.web.middleware.negotiation;
 
+import org.jspecify.annotations.Nullable;
+
 import jakarta.ws.rs.core.MediaType;
 import java.util.Set;
 
@@ -7,8 +9,8 @@ import java.util.Set;
  * @author kawasima
  */
 public interface ContentNegotiator {
-    MediaType bestAllowedContentType(String accept, Set<String> allowedTypes);
-    String bestAllowedCharset(String acceptsHeader, Set<String> available);
-    String bestAllowedEncoding(String acceptsHeader, Set<String> available);
-    String bestAllowedLanguage(String acceptsHeader, Set<String> available);
+    @Nullable MediaType bestAllowedContentType(String accept, Set<String> allowedTypes);
+    @Nullable String bestAllowedCharset(String acceptsHeader, Set<String> available);
+    @Nullable String bestAllowedEncoding(String acceptsHeader, Set<String> available);
+    @Nullable String bestAllowedLanguage(String acceptsHeader, Set<String> available);
 }

--- a/enkan-web/src/main/java/enkan/web/middleware/negotiation/package-info.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/negotiation/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.web.middleware.negotiation;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-web/src/main/java/enkan/web/middleware/normalizer/package-info.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/normalizer/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.web.middleware.normalizer;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-web/src/main/java/enkan/web/middleware/package-info.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.web.middleware;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-web/src/main/java/enkan/web/middleware/session/KeyValueStore.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/session/KeyValueStore.java
@@ -1,5 +1,7 @@
 package enkan.web.middleware.session;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.Serializable;
 
 /**
@@ -21,9 +23,9 @@ public interface KeyValueStore {
      * Read the value.
      *
      * @param key a String contains a store key
-     * @return a stored object
+     * @return a stored object, or {@code null} if absent or expired
      */
-    Serializable read(String key);
+    @Nullable Serializable read(String key);
 
     /**
      * Write the value with the given key.
@@ -32,15 +34,15 @@ public interface KeyValueStore {
      * @param value a stored object
      * @return new store key
      */
-    String write(String key, Serializable value);
+    String write(@Nullable String key, Serializable value);
 
     /**
      * Delete the key and the value.
      *
      * @param key a String contains a store key
-     * @return a String contains a store key
+     * @return a String contains a store key, or {@code null}
      */
-    String delete(String key);
+    @Nullable String delete(String key);
 
     /**
      * Attempts to write the value only if no entry exists for the given key.

--- a/enkan-web/src/main/java/enkan/web/middleware/session/MemoryStore.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/session/MemoryStore.java
@@ -1,5 +1,7 @@
 package enkan.web.middleware.session;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.Closeable;
 import java.io.Serializable;
 import java.util.UUID;
@@ -46,7 +48,7 @@ public class MemoryStore implements KeyValueStore, Closeable {
     }
 
     @Override
-    public Serializable read(String key) {
+    public @Nullable Serializable read(String key) {
         Entry entry = sessionMap.get(key);
         if (entry == null) return null;
         if (System.currentTimeMillis() > entry.expiresAt()) {
@@ -57,7 +59,7 @@ public class MemoryStore implements KeyValueStore, Closeable {
     }
 
     @Override
-    public String write(String key, Serializable value) {
+    public String write(@Nullable String key, Serializable value) {
         if (key == null) {
             key = UUID.randomUUID().toString();
         }
@@ -67,7 +69,7 @@ public class MemoryStore implements KeyValueStore, Closeable {
     }
 
     @Override
-    public String delete(String key) {
+    public @Nullable String delete(String key) {
         sessionMap.remove(key);
         return null;
     }

--- a/enkan-web/src/main/java/enkan/web/middleware/session/package-info.java
+++ b/enkan-web/src/main/java/enkan/web/middleware/session/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.web.middleware.session;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-web/src/main/java/enkan/web/security/backend/SessionBackend.java
+++ b/enkan-web/src/main/java/enkan/web/security/backend/SessionBackend.java
@@ -4,6 +4,8 @@ import enkan.web.data.HttpRequest;
 import enkan.security.AuthBackend;
 import enkan.util.ThreadingUtils;
 
+import org.jspecify.annotations.Nullable;
+
 import java.security.Principal;
 import java.util.Optional;
 
@@ -12,7 +14,7 @@ import java.util.Optional;
  */
 public class SessionBackend implements AuthBackend<HttpRequest, Principal> {
     @Override
-    public Principal parse(HttpRequest request) {
+    public @Nullable Principal parse(HttpRequest request) {
         Optional<Principal> principal = ThreadingUtils.some(request,
                 HttpRequest::getSession,
                 s -> (Principal) s.get("principal"));

--- a/enkan-web/src/main/java/enkan/web/security/backend/TokenBackend.java
+++ b/enkan-web/src/main/java/enkan/web/security/backend/TokenBackend.java
@@ -2,6 +2,9 @@ package enkan.web.security.backend;
 
 import enkan.web.data.HttpRequest;
 import enkan.security.AuthBackend;
+import enkan.web.collection.Headers;
+
+import org.jspecify.annotations.Nullable;
 
 import java.security.Principal;
 
@@ -11,8 +14,9 @@ import java.security.Principal;
 public class TokenBackend implements AuthBackend<HttpRequest, String> {
     private String tokenName = "Token";
 
-    protected String parseAuthorizationHeader(HttpRequest request, String tokenName) {
-        Object authHeader = request.getHeaders().get("Authorization");
+    protected @Nullable String parseAuthorizationHeader(HttpRequest request, String tokenName) {
+        Headers headers = request.getHeaders();
+        Object authHeader = headers != null ? headers.get("Authorization") : null;
         if (authHeader == null) return null;
         String auth = authHeader.toString();
         String prefix = tokenName + " ";
@@ -23,12 +27,12 @@ public class TokenBackend implements AuthBackend<HttpRequest, String> {
     }
 
     @Override
-    public String parse(HttpRequest request) {
+    public @Nullable String parse(HttpRequest request) {
         return parseAuthorizationHeader(request, tokenName);
     }
 
     @Override
-    public Principal authenticate(HttpRequest request, String token) {
+    public @Nullable Principal authenticate(HttpRequest request, String token) {
         return null;
     }
 

--- a/enkan-web/src/main/java/enkan/web/security/backend/package-info.java
+++ b/enkan-web/src/main/java/enkan/web/security/backend/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.web.security.backend;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-web/src/main/java/enkan/web/signature/HttpMessageSignatures.java
+++ b/enkan-web/src/main/java/enkan/web/signature/HttpMessageSignatures.java
@@ -4,6 +4,7 @@ import enkan.security.crypto.Signer;
 import enkan.security.crypto.Verifier;
 import enkan.web.collection.Headers;
 import enkan.web.data.HttpRequest;
+import org.jspecify.annotations.Nullable;
 import enkan.web.data.HttpResponse;
 import enkan.web.http.fields.sf.*;
 
@@ -102,7 +103,7 @@ public final class HttpMessageSignatures {
      * @param verifier       the cryptographic verifier
      * @return the verification result, or {@code null} if verification fails
      */
-    public static VerifyResult verify(HttpRequest request, String label,
+    public static @Nullable VerifyResult verify(HttpRequest request, String label,
                                        SfInnerList signatureInput, byte[] signatureBytes,
                                        Verifier verifier) {
         return verify(request, null, label, signatureInput, signatureBytes, verifier);
@@ -111,7 +112,7 @@ public final class HttpMessageSignatures {
     /**
      * Verifies a single signature on a response.
      */
-    public static VerifyResult verify(HttpRequest request, HttpResponse response,
+    public static @Nullable VerifyResult verify(HttpRequest request, @Nullable HttpResponse response,
                                        String label, SfInnerList signatureInput,
                                        byte[] signatureBytes, Verifier verifier) {
         List<SignatureComponent> components = signatureInput.items().stream()
@@ -173,10 +174,10 @@ public final class HttpMessageSignatures {
     /**
      * Creates a signature over the given response.
      */
-    public static SignatureResult sign(HttpRequest request, HttpResponse response,
+    public static SignatureResult sign(HttpRequest request, @Nullable HttpResponse response,
                                         List<SignatureComponent> components,
                                         SignatureAlgorithm algorithm,
-                                        Signer signer, String keyId, String tag) {
+                                        Signer signer, String keyId, @Nullable String tag) {
         Map<String, SfValue> paramMap = new LinkedHashMap<>();
         paramMap.put("alg", new SfValue.SfString(algorithm.sfName()));
         paramMap.put("keyid", new SfValue.SfString(keyId));
@@ -215,7 +216,10 @@ public final class HttpMessageSignatures {
      * This method retrieves the raw object via the {@code Map<String,Object>} view
      * and joins list values with {@code ", "} before SF parsing.
      */
-    private static String getHeaderForParsing(Headers headers, String name) {
+    private static @Nullable String getHeaderForParsing(@Nullable Headers headers, String name) {
+        if (headers == null) {
+            return null;
+        }
         // Parameters.get() overrides Map.get() to return val.toString(), losing List structure.
         // Use entrySet() to access the raw Object value for proper multi-value joining.
         String lowerName = name.toLowerCase(Locale.ROOT);

--- a/enkan-web/src/main/java/enkan/web/signature/SignatureBaseBuilder.java
+++ b/enkan-web/src/main/java/enkan/web/signature/SignatureBaseBuilder.java
@@ -2,6 +2,7 @@ package enkan.web.signature;
 
 import enkan.exception.MisconfigurationException;
 import enkan.web.data.HttpRequest;
+import org.jspecify.annotations.Nullable;
 import enkan.web.data.HttpResponse;
 import enkan.web.http.fields.sf.*;
 
@@ -48,7 +49,7 @@ public final class SignatureBaseBuilder {
      * @return the signature base string
      */
     public static String buildSignatureBase(HttpRequest request,
-                                            HttpResponse response,
+                                            @Nullable HttpResponse response,
                                             List<SignatureComponent> components,
                                             SfParameters params) {
         StringBuilder sb = new StringBuilder();
@@ -72,7 +73,7 @@ public final class SignatureBaseBuilder {
     /**
      * Resolves the value of a single component from the request/response.
      */
-    static String resolveComponentValue(HttpRequest request, HttpResponse response,
+    static String resolveComponentValue(HttpRequest request, @Nullable HttpResponse response,
                                         SignatureComponent component) {
         if (component.isDerived()) {
             return resolveDerived(request, response, component);
@@ -99,10 +100,10 @@ public final class SignatureBaseBuilder {
     // Derived components (§2.2)
     // -------------------------------------------------------------------------
 
-    private static String resolveDerived(HttpRequest request, HttpResponse response,
+    private static String resolveDerived(HttpRequest request, @Nullable HttpResponse response,
                                          SignatureComponent component) {
         return switch (component.name()) {
-            case "@method" -> request.getRequestMethod().toUpperCase(Locale.ROOT);
+            case "@method" -> java.util.Objects.requireNonNull(request.getRequestMethod()).toUpperCase(Locale.ROOT);
             case "@path" -> {
                 String uri = request.getUri();
                 yield (uri == null || uri.isEmpty()) ? "/" : uri;
@@ -111,7 +112,7 @@ public final class SignatureBaseBuilder {
                 String qs = request.getQueryString();
                 yield "?" + (qs != null ? qs : "");
             }
-            case "@scheme" -> request.getScheme().toLowerCase(Locale.ROOT);
+            case "@scheme" -> java.util.Objects.requireNonNull(request.getScheme()).toLowerCase(Locale.ROOT);
             case "@authority" -> resolveAuthority(request);
             case "@target-uri" -> resolveTargetUri(request);
             case "@request-target" -> {
@@ -133,11 +134,11 @@ public final class SignatureBaseBuilder {
 
     private static String resolveAuthority(HttpRequest request) {
         // RFC 9421 §2.2.5: prefer the Host header when present (reflects what the client signed)
-        Object hostHeader = request.getHeaders().get("host");
+        Object hostHeader = java.util.Objects.requireNonNull(request.getHeaders()).get("host");
         if (hostHeader != null) {
             return hostHeader.toString().strip().toLowerCase(Locale.ROOT);
         }
-        String host = request.getServerName().toLowerCase(Locale.ROOT);
+        String host = java.util.Objects.requireNonNull(request.getServerName()).toLowerCase(Locale.ROOT);
         int port = request.getServerPort();
         String scheme = request.getScheme();
         boolean defaultPort = ("http".equals(scheme) && port == 80)
@@ -147,7 +148,7 @@ public final class SignatureBaseBuilder {
     }
 
     private static String resolveTargetUri(HttpRequest request) {
-        String scheme = request.getScheme().toLowerCase(Locale.ROOT);
+        String scheme = java.util.Objects.requireNonNull(request.getScheme()).toLowerCase(Locale.ROOT);
         String authority = resolveAuthority(request);
         String path = request.getUri();
         if (path == null || path.isEmpty()) path = "/";
@@ -212,18 +213,18 @@ public final class SignatureBaseBuilder {
     // Header components (§2.1)
     // -------------------------------------------------------------------------
 
-    private static String resolveHeader(HttpRequest request, HttpResponse response,
+    private static String resolveHeader(HttpRequest request, @Nullable HttpResponse response,
                                         SignatureComponent component) {
         // Headers stores keys in ASCII lowercase (see Headers class Javadoc), so the
         // lowercase component.name() from SignatureComponent always matches the stored key.
         // ;req flag: resolve from request even when signing a response
         Object headerObj;
         if (component.isReq() && response != null) {
-            headerObj = request.getHeaders().get(component.name());
+            headerObj = java.util.Objects.requireNonNull(request.getHeaders()).get(component.name());
         } else if (response != null && !component.isReq()) {
             headerObj = response.getHeaders().get(component.name());
         } else {
-            headerObj = request.getHeaders().get(component.name());
+            headerObj = java.util.Objects.requireNonNull(request.getHeaders()).get(component.name());
         }
 
         if (headerObj == null) {

--- a/enkan-web/src/main/java/enkan/web/signature/SignatureComponent.java
+++ b/enkan-web/src/main/java/enkan/web/signature/SignatureComponent.java
@@ -4,6 +4,8 @@ import enkan.web.http.fields.sf.SfItem;
 import enkan.web.http.fields.sf.SfParameters;
 import enkan.web.http.fields.sf.SfValue;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Locale;
 
 /**
@@ -55,13 +57,13 @@ public record SignatureComponent(String name, SfParameters parameters) {
     }
 
     /** Returns the value of the {@code ;key} parameter, or {@code null} if absent. */
-    public String keyParam() {
+    public @Nullable String keyParam() {
         SfValue v = parameters.get("key");
         return v instanceof SfValue.SfString s ? s.value() : null;
     }
 
     /** Returns the value of the {@code ;name} parameter, or {@code null} if absent. */
-    public String nameParam() {
+    public @Nullable String nameParam() {
         SfValue v = parameters.get("name");
         return v instanceof SfValue.SfString s ? s.value() : null;
     }

--- a/enkan-web/src/main/java/enkan/web/signature/VerifyResult.java
+++ b/enkan-web/src/main/java/enkan/web/signature/VerifyResult.java
@@ -1,5 +1,7 @@
 package enkan.web.signature;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Map;
 
 /**
@@ -18,7 +20,7 @@ import java.util.Map;
  */
 public record VerifyResult(
         String label,
-        String keyId,
-        SignatureAlgorithm algorithm,
+        @Nullable String keyId,
+        @Nullable SignatureAlgorithm algorithm,
         Map<String, String> coveredValues) {
 }

--- a/enkan-web/src/main/java/enkan/web/signature/package-info.java
+++ b/enkan-web/src/main/java/enkan/web/signature/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.web.signature;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-web/src/main/java/enkan/web/util/ETagUtils.java
+++ b/enkan-web/src/main/java/enkan/web/util/ETagUtils.java
@@ -1,5 +1,7 @@
 package enkan.web.util;
 
+import org.jspecify.annotations.Nullable;
+
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -33,7 +35,7 @@ public final class ETagUtils {
      * @param contentEncoding the Content-Encoding header value, or null
      * @return a weak ETag string, or null if the body type is not supported
      */
-    public static String generateWeakETag(Object body, String contentEncoding) {
+    public static @Nullable String generateWeakETag(@Nullable Object body, @Nullable String contentEncoding) {
         byte[] data;
         if (body instanceof String s) {
             data = s.getBytes(StandardCharsets.UTF_8);
@@ -100,7 +102,7 @@ public final class ETagUtils {
      * @param weakComparison true for If-None-Match (weak), false for If-Match (strong)
      * @return true if a match is found
      */
-    public static boolean matchesHeader(String headerValue, String etag, boolean weakComparison) {
+    public static boolean matchesHeader(String headerValue, @Nullable String etag, boolean weakComparison) {
         if (headerValue == null || etag == null) return false;
         String trimmed = headerValue.strip();
         if ("*".equals(trimmed)) return true;

--- a/enkan-web/src/main/java/enkan/web/util/HttpRequestUtils.java
+++ b/enkan-web/src/main/java/enkan/web/util/HttpRequestUtils.java
@@ -1,6 +1,9 @@
 package enkan.web.util;
 
+import enkan.web.collection.Headers;
 import enkan.web.data.HttpRequest;
+
+import org.jspecify.annotations.Nullable;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -18,10 +21,11 @@ public class HttpRequestUtils {
     private static final Pattern CHARSET_PATTERN = Pattern.compile(";(?:.*\\s)?(?i:charset)=(" + RE_VALUE + ")\\s*(?:;|$)");
     private static final Pattern CONTENT_TYPE_PATTERN = Pattern.compile("^(.*?)(?:;|$)");
     public static String requestUrl(HttpRequest request) {
+        Headers headers = request.getHeaders();
         StringBuilder sb = new StringBuilder()
                 .append(request.getScheme())
                 .append("://")
-                .append(request.getHeaders().get("host"))
+                .append(headers != null ? headers.get("host") : null)
                 .append(request.getUri());
         String queryString = request.getQueryString();
         if (queryString != null) {
@@ -31,7 +35,7 @@ public class HttpRequestUtils {
         return sb.toString();
     }
 
-    public static String contentType(HttpRequest request) {
+    public static @Nullable String contentType(HttpRequest request) {
         String type = some(request.getHeaders(), headers -> headers.get("content-type")).orElse(null);
         if (type == null) return null;
 
@@ -39,8 +43,9 @@ public class HttpRequestUtils {
         return m.find() ? m.group(1) : null;
     }
 
-    public static Long contentLength(HttpRequest request) {
-        String length = request.getHeaders().get("content-length");
+    public static @Nullable Long contentLength(HttpRequest request) {
+        Headers headers = request.getHeaders();
+        String length = headers != null ? headers.get("content-length") : null;
         if (length != null) {
             try {
                 return Long.parseLong(length, 10);
@@ -51,15 +56,16 @@ public class HttpRequestUtils {
         return null;
     }
 
-    public static String characterEncoding(HttpRequest request) {
-        String type = request.getHeaders().get("content-type");
+    public static @Nullable String characterEncoding(HttpRequest request) {
+        Headers headers = request.getHeaders();
+        String type = headers != null ? headers.get("content-type") : null;
         if (type == null) return null;
 
         Matcher m = CHARSET_PATTERN.matcher(type);
         return m.find() ? m.group(1) : null;
     }
 
-    public static String pathInfo(HttpRequest request) {
+    public static @Nullable String pathInfo(HttpRequest request) {
         return request.getUri();
     }
 

--- a/enkan-web/src/main/java/enkan/web/util/HttpResponseUtils.java
+++ b/enkan-web/src/main/java/enkan/web/util/HttpResponseUtils.java
@@ -6,6 +6,8 @@ import enkan.web.data.HttpResponse;
 import enkan.exception.FalteringEnvironmentException;
 import enkan.exception.UnreachableException;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -128,7 +130,7 @@ public class HttpResponseUtils {
      * @return the header value
      */
     @SuppressWarnings("unchecked")
-    public static <T> T getHeader(HttpResponse response, String name) {
+    public static <T> @Nullable T getHeader(HttpResponse response, String name) {
         return (T) response.getHeaders().get(name);
     }
 
@@ -224,7 +226,7 @@ public class HttpResponseUtils {
      * @param len the length of response message
      * @return a HttpResponse contains content-length header
      */
-    public static HttpResponse contentLength(HttpResponse response, Long len) {
+    public static HttpResponse contentLength(HttpResponse response, @Nullable Long len) {
         if (len != null) {
             response.getHeaders().remove("Content-Length");
             response.getHeaders().put("Content-Length", len);
@@ -240,7 +242,7 @@ public class HttpResponseUtils {
      * @param lastModified the last-modified date
      * @return the same response object
      */
-    public static HttpResponse lastModified(HttpResponse response, Date lastModified) {
+    public static HttpResponse lastModified(HttpResponse response, @Nullable Date lastModified) {
         if (lastModified != null) {
             response.getHeaders().remove("Last-Modified");
             response.getHeaders().put("Last-Modified", HttpDateFormat.RFC1123.format(lastModified));
@@ -272,7 +274,7 @@ public class HttpResponseUtils {
      * @param conn a URL connection
      * @return content length in bytes, or {@code null}
      */
-    public static Long connectionContentLength(URLConnection conn) {
+    public static @Nullable Long connectionContentLength(URLConnection conn) {
         long len = conn.getContentLengthLong();
         return len <= 0 ? null : len;
     }
@@ -283,7 +285,7 @@ public class HttpResponseUtils {
      * @param conn a URL connection
      * @return last-modified date, or {@code null}
      */
-    public static Date connectionLastModified(URLConnection conn) {
+    public static @Nullable Date connectionLastModified(URLConnection conn) {
         long lastMod = conn.getLastModified();
         return lastMod > 0 ? new Date(lastMod) : null;
     }
@@ -295,7 +297,7 @@ public class HttpResponseUtils {
      * @param url the resource URL
      * @return content data, or {@code null}
      */
-    public static ContentData<?> resourceData(URL url) {
+    public static @Nullable ContentData<?> resourceData(URL url) {
         String protocol = url.getProtocol();
         if ("file".equals(protocol)) {
             try {
@@ -329,7 +331,7 @@ public class HttpResponseUtils {
      * @param url the resource URL
      * @return response, or {@code null} if the URL points to a directory
      */
-    public static HttpResponse urlResponse(URL url) {
+    public static @Nullable HttpResponse urlResponse(URL url) {
         ContentData<?> data = resourceData(url);
         if (data == null) return null;
 
@@ -349,7 +351,7 @@ public class HttpResponseUtils {
      * @param options options map accepting {@code root} (String) and {@code loader} (ClassLoader)
      * @return response, or {@code null} if the resource is not found
      */
-    public static HttpResponse resourceResponse(String path, OptionMap options) {
+    public static @Nullable HttpResponse resourceResponse(String path, OptionMap options) {
         String root = options.getString("root");
         path = (root != null ? root : "") + "/" + path;
         path = path.replace("//", "/").replaceAll("^/", "");
@@ -375,10 +377,10 @@ public class HttpResponseUtils {
 
     private static abstract class ContentData<T> implements Serializable {
         private final T content;
-        private final Long contentLength;
-        private final Date lastModifiedDate;
+        private final @Nullable Long contentLength;
+        private final @Nullable Date lastModifiedDate;
 
-        public ContentData(T content, Long contentLength, Date lastModifiedDate) {
+        public ContentData(T content, @Nullable Long contentLength, @Nullable Date lastModifiedDate) {
             this.content = content;
             this.contentLength = contentLength;
             this.lastModifiedDate = lastModifiedDate;
@@ -388,11 +390,11 @@ public class HttpResponseUtils {
             return content;
         }
 
-        public Long getContentLength() {
+        public @Nullable Long getContentLength() {
             return contentLength;
         }
 
-        public Date getLastModifiedDate() {
+        public @Nullable Date getLastModifiedDate() {
             return lastModifiedDate;
         }
 
@@ -400,7 +402,7 @@ public class HttpResponseUtils {
     }
 
     private static class FileContentData extends ContentData<File> {
-        public FileContentData(File content, Long contentLength, Date lastModifiedDate) {
+        public FileContentData(File content, @Nullable Long contentLength, @Nullable Date lastModifiedDate) {
             super(content, contentLength, lastModifiedDate);
         }
 
@@ -411,7 +413,7 @@ public class HttpResponseUtils {
     }
 
     private static class StreamContentData extends ContentData<InputStream> {
-        public StreamContentData(InputStream content, Long contentLength, Date lastModifiedDate) {
+        public StreamContentData(InputStream content, @Nullable Long contentLength, @Nullable Date lastModifiedDate) {
             super(content, contentLength, lastModifiedDate);
         }
 

--- a/enkan-web/src/main/java/enkan/web/util/package-info.java
+++ b/enkan-web/src/main/java/enkan/web/util/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.web.util;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-web/src/main/java/enkan/web/websocket/package-info.java
+++ b/enkan-web/src/main/java/enkan/web/websocket/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.web.websocket;
+
+import org.jspecify.annotations.NullMarked;

--- a/enkan-web/src/main/java/module-info.java
+++ b/enkan-web/src/main/java/module-info.java
@@ -19,6 +19,7 @@ module enkan.web {
 
     requires transitive enkan.core;
     requires transitive enkan.system;
+    requires transitive org.jspecify;
     requires jakarta.cdi;
     requires jakarta.validation;
     requires transitive jakarta.ws.rs;

--- a/kotowari-graalvm/pom.xml
+++ b/kotowari-graalvm/pom.xml
@@ -17,6 +17,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.unit8.enkan</groupId>
             <artifactId>enkan-core</artifactId>
             <version>${enkan.version}</version>

--- a/kotowari-graalvm/src/main/java/enkan/graalvm/NativeComponentRegistry.java
+++ b/kotowari-graalvm/src/main/java/enkan/graalvm/NativeComponentRegistry.java
@@ -1,5 +1,7 @@
 package enkan.graalvm;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -22,7 +24,7 @@ public final class NativeComponentRegistry {
     }
 
     @SuppressWarnings("unchecked")
-    public static <T> ComponentBinder<T> get(Class<T> componentClass) {
+    public static <T> @Nullable ComponentBinder<T> get(Class<T> componentClass) {
         return (ComponentBinder<T>) BINDERS.get(componentClass);
     }
 

--- a/kotowari-graalvm/src/main/java/enkan/graalvm/package-info.java
+++ b/kotowari-graalvm/src/main/java/enkan/graalvm/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package enkan.graalvm;
+
+import org.jspecify.annotations.NullMarked;

--- a/kotowari-graalvm/src/main/java/kotowari/graalvm/KotowariFeature.java
+++ b/kotowari-graalvm/src/main/java/kotowari/graalvm/KotowariFeature.java
@@ -5,6 +5,7 @@ import kotowari.routing.Route;
 import kotowari.routing.Routes;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.lang.classfile.ClassFile;
@@ -151,7 +152,7 @@ public class KotowariFeature implements Feature {
         }
     }
 
-    private Routes resolveRoutes(BeforeAnalysisAccess access) {
+    private @Nullable Routes resolveRoutes(BeforeAnalysisAccess access) {
         Routes routes = RouteRegistry.get();
         if (routes != null) {
             return routes;

--- a/kotowari-graalvm/src/main/java/kotowari/graalvm/NativeControllerInvokerMiddleware.java
+++ b/kotowari-graalvm/src/main/java/kotowari/graalvm/NativeControllerInvokerMiddleware.java
@@ -39,7 +39,7 @@ public class NativeControllerInvokerMiddleware<RES> implements Middleware<HttpRe
     private final Map<Class<?>, Object> controllerCache = new ConcurrentHashMap<>();
     private final Map<String, ParameterInjector<?>[]> injectorCache = new ConcurrentHashMap<>();
     private static final ParameterInjector<?> BODY_SERIALIZABLE_INJECTOR = new BodySerializableInjector<>();
-    private List<ParameterInjector<?>> parameterInjectors;
+    private List<ParameterInjector<?>> parameterInjectors = ParameterUtils.getDefaultParameterInjectors();
 
     public NativeControllerInvokerMiddleware(ComponentInjector componentInjector) {
         this.componentInjector = componentInjector;
@@ -47,9 +47,8 @@ public class NativeControllerInvokerMiddleware<RES> implements Middleware<HttpRe
 
     @PostConstruct
     protected void setupParameterInjectors() {
-        if (parameterInjectors == null) {
-            parameterInjectors = ParameterUtils.getDefaultParameterInjectors();
-        }
+        // parameterInjectors is initialized inline; retained as a @PostConstruct
+        // hook and for callers that invoke it directly.
     }
 
     private ParameterInjector<?>[] resolveInjectors(Method method) {

--- a/kotowari-graalvm/src/main/java/kotowari/graalvm/NativeDispatcherRegistry.java
+++ b/kotowari-graalvm/src/main/java/kotowari/graalvm/NativeDispatcherRegistry.java
@@ -13,7 +13,7 @@ package kotowari.graalvm;
  * no memory-visibility guarantee is needed once the value is baked into the heap.
  */
 public final class NativeDispatcherRegistry {
-    private static KotowariDispatcherInvoker invoker;
+    private static @org.jspecify.annotations.Nullable KotowariDispatcherInvoker invoker;
 
     private NativeDispatcherRegistry() {}
 
@@ -21,7 +21,7 @@ public final class NativeDispatcherRegistry {
         invoker = inv;
     }
 
-    public static KotowariDispatcherInvoker get() {
+    public static @org.jspecify.annotations.Nullable KotowariDispatcherInvoker get() {
         return invoker;
     }
 }

--- a/kotowari-graalvm/src/main/java/kotowari/graalvm/RouteRegistry.java
+++ b/kotowari-graalvm/src/main/java/kotowari/graalvm/RouteRegistry.java
@@ -2,6 +2,8 @@ package kotowari.graalvm;
 
 import kotowari.routing.Routes;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -27,7 +29,7 @@ public final class RouteRegistry {
         INSTANCE.set(routes);
     }
 
-    public static Routes get() {
+    public static @Nullable Routes get() {
         return INSTANCE.get();
     }
 }

--- a/kotowari-graalvm/src/main/java/kotowari/graalvm/package-info.java
+++ b/kotowari-graalvm/src/main/java/kotowari/graalvm/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package kotowari.graalvm;
+
+import org.jspecify.annotations.NullMarked;

--- a/kotowari-graalvm/src/main/java/module-info.java
+++ b/kotowari-graalvm/src/main/java/module-info.java
@@ -8,6 +8,7 @@ module kotowari.graalvm {
     requires jakarta.annotation;
     requires transitive kotowari;
     requires transitive org.graalvm.nativeimage;
+    requires transitive org.jspecify;
 
     opens kotowari.graalvm;
     opens enkan.graalvm;

--- a/kotowari-jpa/pom.xml
+++ b/kotowari-jpa/pom.xml
@@ -16,6 +16,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.unit8.enkan</groupId>
             <artifactId>enkan-component-jpa</artifactId>
             <version>${enkan.version}</version>

--- a/kotowari-jpa/src/main/java/kotowari/inject/parameter/EntityManagerInjector.java
+++ b/kotowari-jpa/src/main/java/kotowari/inject/parameter/EntityManagerInjector.java
@@ -4,6 +4,8 @@ import enkan.web.data.HttpRequest;
 import enkan.data.jpa.EntityManageable;
 import kotowari.inject.ParameterInjector;
 
+import org.jspecify.annotations.Nullable;
+
 import jakarta.persistence.EntityManager;
 import java.util.Optional;
 
@@ -33,7 +35,7 @@ public class EntityManagerInjector implements ParameterInjector<EntityManager> {
      * {@inheritDoc}
      */
     @Override
-    public EntityManager getInjectObject(HttpRequest request) {
+    public @Nullable EntityManager getInjectObject(HttpRequest request) {
         return Optional.ofNullable(request)
                 .filter(EntityManageable.class::isInstance)
                 .map(EntityManageable.class::cast)

--- a/kotowari-jpa/src/main/java/kotowari/inject/parameter/package-info.java
+++ b/kotowari-jpa/src/main/java/kotowari/inject/parameter/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package kotowari.inject.parameter;
+
+import org.jspecify.annotations.NullMarked;

--- a/kotowari/pom.xml
+++ b/kotowari/pom.xml
@@ -35,6 +35,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.unit8.enkan</groupId>
             <artifactId>enkan-web</artifactId>
             <version>${enkan.version}</version>
@@ -82,4 +86,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
 </project>

--- a/kotowari/src/main/java/kotowari/component/package-info.java
+++ b/kotowari/src/main/java/kotowari/component/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package kotowari.component;
+
+import org.jspecify.annotations.NullMarked;

--- a/kotowari/src/main/java/kotowari/data/BodyDeserializable.java
+++ b/kotowari/src/main/java/kotowari/data/BodyDeserializable.java
@@ -2,17 +2,19 @@ package kotowari.data;
 
 import enkan.data.Extendable;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Binds the http parameters to a specified form object.
  *
  * @author kawasima
  */
 public interface BodyDeserializable extends Extendable {
-    default <T> T getDeserializedBody() {
+    default <T> @Nullable T getDeserializedBody() {
         return getExtension("deserializedBody");
     }
 
-    default <T> void setDeserializedBody(T obj) {
+    default <T> void setDeserializedBody(@Nullable T obj) {
         setExtension("deserializedBody", obj);
     }
 }

--- a/kotowari/src/main/java/kotowari/data/Validatable.java
+++ b/kotowari/src/main/java/kotowari/data/Validatable.java
@@ -4,6 +4,8 @@ import enkan.collection.Multimap;
 import enkan.data.Extendable;
 import enkan.util.ThreadingUtils;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.List;
 
 /**
@@ -23,10 +25,11 @@ public interface Validatable extends Extendable {
     }
 
     default List<Object> getErrors(String key) {
-        return getErrors().getAll(key);
+        Multimap<String, Object> errors = getErrors();
+        return errors == null ? List.of() : errors.getAll(key);
     }
 
-    default Multimap<String, Object> getErrors() {
+    default @Nullable Multimap<String, Object> getErrors() {
         return getExtension("errors");
     }
 

--- a/kotowari/src/main/java/kotowari/data/package-info.java
+++ b/kotowari/src/main/java/kotowari/data/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package kotowari.data;
+
+import org.jspecify.annotations.NullMarked;

--- a/kotowari/src/main/java/kotowari/inject/ParameterInjector.java
+++ b/kotowari/src/main/java/kotowari/inject/ParameterInjector.java
@@ -2,6 +2,8 @@ package kotowari.inject;
 
 import enkan.web.data.HttpRequest;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Inject object to a controller method.
  *
@@ -33,7 +35,7 @@ public interface ParameterInjector<T> {
      * Get a object for injecting.
      *
      * @param request the request object
-     * @return an object for injection
+     * @return an object for injection, or {@code null} if the request carries none
      */
-    T getInjectObject(HttpRequest request);
+    @Nullable T getInjectObject(HttpRequest request);
 }

--- a/kotowari/src/main/java/kotowari/inject/package-info.java
+++ b/kotowari/src/main/java/kotowari/inject/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package kotowari.inject;
+
+import org.jspecify.annotations.NullMarked;

--- a/kotowari/src/main/java/kotowari/inject/parameter/BodySerializableInjector.java
+++ b/kotowari/src/main/java/kotowari/inject/parameter/BodySerializableInjector.java
@@ -4,6 +4,8 @@ import enkan.web.data.HttpRequest;
 import kotowari.data.BodyDeserializable;
 import kotowari.inject.RuntimeParameterInjector;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Injects the deserialized request body when it is type-compatible.
  *
@@ -40,7 +42,7 @@ public class BodySerializableInjector<T> implements RuntimeParameterInjector<T> 
     }
 
     @Override
-    public T getInjectObject(HttpRequest request) {
+    public @Nullable T getInjectObject(HttpRequest request) {
         return ((BodyDeserializable) request).getDeserializedBody();
     }
 }

--- a/kotowari/src/main/java/kotowari/inject/parameter/ConversationInjector.java
+++ b/kotowari/src/main/java/kotowari/inject/parameter/ConversationInjector.java
@@ -3,6 +3,8 @@ package kotowari.inject.parameter;
 import enkan.web.data.HttpRequest;
 import kotowari.inject.ParameterInjector;
 
+import org.jspecify.annotations.Nullable;
+
 import jakarta.enterprise.context.Conversation;
 
 public class ConversationInjector implements ParameterInjector<Conversation> {
@@ -17,7 +19,7 @@ public class ConversationInjector implements ParameterInjector<Conversation> {
     }
 
     @Override
-    public Conversation getInjectObject(HttpRequest request) {
+    public @Nullable Conversation getInjectObject(HttpRequest request) {
         return request.getConversation();
     }
 }

--- a/kotowari/src/main/java/kotowari/inject/parameter/FlashInjector.java
+++ b/kotowari/src/main/java/kotowari/inject/parameter/FlashInjector.java
@@ -4,6 +4,8 @@ import enkan.data.Flash;
 import enkan.web.data.HttpRequest;
 import kotowari.inject.ParameterInjector;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.Serializable;
 
 public class FlashInjector<T extends Serializable> implements ParameterInjector<Flash<T>> {
@@ -19,7 +21,7 @@ public class FlashInjector<T extends Serializable> implements ParameterInjector<
 
     @Override
     @SuppressWarnings("unchecked")
-    public Flash<T> getInjectObject(HttpRequest request) {
+    public @Nullable Flash<T> getInjectObject(HttpRequest request) {
         return (Flash<T>) request.getFlash();
     }
 }

--- a/kotowari/src/main/java/kotowari/inject/parameter/LocaleInjector.java
+++ b/kotowari/src/main/java/kotowari/inject/parameter/LocaleInjector.java
@@ -4,6 +4,8 @@ import enkan.web.data.ContentNegotiable;
 import enkan.web.data.HttpRequest;
 import kotowari.inject.ParameterInjector;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Locale;
 
 public class LocaleInjector implements ParameterInjector<Locale> {
@@ -18,7 +20,7 @@ public class LocaleInjector implements ParameterInjector<Locale> {
     }
 
     @Override
-    public Locale getInjectObject(HttpRequest request) {
+    public @Nullable Locale getInjectObject(HttpRequest request) {
         if (request instanceof ContentNegotiable cn) {
             return cn.getLocale();
         }

--- a/kotowari/src/main/java/kotowari/inject/parameter/ParametersInjector.java
+++ b/kotowari/src/main/java/kotowari/inject/parameter/ParametersInjector.java
@@ -4,6 +4,8 @@ import enkan.collection.Parameters;
 import enkan.web.data.HttpRequest;
 import kotowari.inject.ParameterInjector;
 
+import org.jspecify.annotations.Nullable;
+
 public class ParametersInjector implements ParameterInjector<Parameters> {
     @Override
     public String getName() {
@@ -16,7 +18,7 @@ public class ParametersInjector implements ParameterInjector<Parameters> {
     }
 
     @Override
-    public Parameters getInjectObject(HttpRequest request) {
+    public @Nullable Parameters getInjectObject(HttpRequest request) {
         return request.getParams();
     }
 }

--- a/kotowari/src/main/java/kotowari/inject/parameter/PrincipalInjector.java
+++ b/kotowari/src/main/java/kotowari/inject/parameter/PrincipalInjector.java
@@ -3,6 +3,8 @@ package kotowari.inject.parameter;
 import enkan.web.data.HttpRequest;
 import kotowari.inject.ParameterInjector;
 
+import org.jspecify.annotations.Nullable;
+
 import java.security.Principal;
 
 public class PrincipalInjector implements ParameterInjector<Principal> {
@@ -17,10 +19,9 @@ public class PrincipalInjector implements ParameterInjector<Principal> {
     }
 
     @Override
-    public Principal getInjectObject(HttpRequest request) {
-        if (request != null) {
-            return request.getPrincipal();
-        }
-        return null;
+    @SuppressWarnings("ConstantValue")
+    public @Nullable Principal getInjectObject(HttpRequest request) {
+        //noinspection ConstantValue - tolerate a null request defensively
+        return request != null ? request.getPrincipal() : null;
     }
 }

--- a/kotowari/src/main/java/kotowari/inject/parameter/SessionInjector.java
+++ b/kotowari/src/main/java/kotowari/inject/parameter/SessionInjector.java
@@ -4,6 +4,8 @@ import enkan.web.data.HttpRequest;
 import enkan.data.Session;
 import kotowari.inject.ParameterInjector;
 
+import org.jspecify.annotations.Nullable;
+
 public class SessionInjector implements ParameterInjector<Session> {
     @Override
     public String getName() {
@@ -16,7 +18,7 @@ public class SessionInjector implements ParameterInjector<Session> {
     }
 
     @Override
-    public Session getInjectObject(HttpRequest request) {
+    public @Nullable Session getInjectObject(HttpRequest request) {
         return request.getSession();
     }
 }

--- a/kotowari/src/main/java/kotowari/inject/parameter/package-info.java
+++ b/kotowari/src/main/java/kotowari/inject/parameter/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package kotowari.inject.parameter;
+
+import org.jspecify.annotations.NullMarked;

--- a/kotowari/src/main/java/kotowari/io/LazyRenderInputStream.java
+++ b/kotowari/src/main/java/kotowari/io/LazyRenderInputStream.java
@@ -1,5 +1,7 @@
 package kotowari.io;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -8,7 +10,7 @@ import java.io.InputStream;
  */
 public class LazyRenderInputStream extends InputStream {
     private final LazyRenderer renderer;
-    private InputStream in;
+    private @Nullable InputStream in;
 
     public LazyRenderInputStream(LazyRenderer renderer) {
         this.renderer = renderer;
@@ -16,10 +18,12 @@ public class LazyRenderInputStream extends InputStream {
 
     @Override
     public int read() throws IOException {
-        if (in == null) {
-            in = renderer.render();
+        InputStream stream = in;
+        if (stream == null) {
+            stream = renderer.render();
+            in = stream;
         }
-        return in.read();
+        return stream.read();
     }
 
     @Override

--- a/kotowari/src/main/java/kotowari/io/package-info.java
+++ b/kotowari/src/main/java/kotowari/io/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package kotowari.io;
+
+import org.jspecify.annotations.NullMarked;

--- a/kotowari/src/main/java/kotowari/middleware/ControllerInvokerMiddleware.java
+++ b/kotowari/src/main/java/kotowari/middleware/ControllerInvokerMiddleware.java
@@ -44,7 +44,7 @@ public class ControllerInvokerMiddleware<RES> implements Middleware<HttpRequest,
     private final Map<Method, MethodInvocation> methodCache = new ConcurrentHashMap<>();
     private final ComponentInjector componentInjector;
     private static final ParameterInjector<?> BODY_SERIALIZABLE_INJECTOR = new BodySerializableInjector<>();
-    private List<ParameterInjector<?>> parameterInjectors;
+    private List<ParameterInjector<?>> parameterInjectors = ParameterUtils.getDefaultParameterInjectors();
 
     // Fixed-arity functional interfaces so LambdaMetafactory generates
     // direct invokevirtual/invokestatic bytecode (JIT-inlinable).
@@ -83,9 +83,8 @@ public class ControllerInvokerMiddleware<RES> implements Middleware<HttpRequest,
 
     @PostConstruct
     protected void setupParameterInjectors() {
-        if (parameterInjectors == null) {
-            parameterInjectors = ParameterUtils.getDefaultParameterInjectors();
-        }
+        // parameterInjectors is initialized to the defaults at construction; this
+        // remains as the CDI lifecycle hook (and is invoked directly by tests).
     }
 
     /**

--- a/kotowari/src/main/java/kotowari/middleware/FormMiddleware.java
+++ b/kotowari/src/main/java/kotowari/middleware/FormMiddleware.java
@@ -15,13 +15,15 @@ import kotowari.data.BodyDeserializable;
 import kotowari.inject.ParameterInjector;
 import kotowari.util.ParameterUtils;
 
-import jakarta.annotation.PostConstruct;
+import org.jspecify.annotations.Nullable;
+
 import jakarta.inject.Inject;
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Sets the form object to the request.
@@ -33,17 +35,10 @@ public class FormMiddleware implements WebMiddleware {
     @Inject
     protected BeansConverter beans;
 
-    private List<ParameterInjector<?>> parameterInjectors;
-
-    @PostConstruct
-    protected void setupParameterInjectors() {
-        if (parameterInjectors == null) {
-            parameterInjectors = ParameterUtils.getDefaultParameterInjectors();
-        }
-    }
+    private List<ParameterInjector<?>> parameterInjectors = ParameterUtils.getDefaultParameterInjectors();
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
         Method method = ((Routable) request).getControllerMethod();
         if (method == null) {
             throw new MisconfigurationException("kotowari.CONTROLLER_METHOD_NOT_FOUND", "FormMiddleware");
@@ -59,10 +54,12 @@ public class FormMiddleware implements WebMiddleware {
             try {
                 if (body == null) {
                     if (!Collection.class.isAssignableFrom(type) && !type.isArray()) {
-                        bodyDeserializable.setDeserializedBody(beans.createFrom(request.getParams(), type));
+                        bodyDeserializable.setDeserializedBody(beans.createFrom(
+                                Objects.requireNonNull(request.getParams(), "request params"), type));
                     }
                 } else {
-                    beans.copy(request.getParams(), body, BeansConverter.CopyOption.REPLACE_NON_NULL);
+                    beans.copy(Objects.requireNonNull(request.getParams(), "request params"),
+                            body, BeansConverter.CopyOption.REPLACE_NON_NULL);
                     bodyDeserializable.setDeserializedBody(body);
                 }
             } catch (ClassCastException e) {

--- a/kotowari/src/main/java/kotowari/middleware/RenderTemplateMiddleware.java
+++ b/kotowari/src/main/java/kotowari/middleware/RenderTemplateMiddleware.java
@@ -27,6 +27,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -110,7 +112,7 @@ public class RenderTemplateMiddleware implements WebMiddleware {
     }
 
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> chain) {
         HttpResponse response = castToHttpResponse(chain.next(request));
         if (response instanceof TemplatedHttpResponse tres) {
             if (exports.contains(REQUEST)) {
@@ -139,7 +141,7 @@ public class RenderTemplateMiddleware implements WebMiddleware {
             if (exports.contains(CONVERSATION)) {
                 Conversation conversation = request.getConversation();
                 if (conversation != null) {
-                    if (!request.getConversation().isTransient()) {
+                    if (!conversation.isTransient()) {
                         String token = conversation.getId() + "$"
                                 + hmacEncoder.encodeToHex(conversation.getId() + "$" + conversation.getTimeout())
                                 + "$" + conversation.getTimeout();

--- a/kotowari/src/main/java/kotowari/middleware/RoutingMiddleware.java
+++ b/kotowari/src/main/java/kotowari/middleware/RoutingMiddleware.java
@@ -23,7 +23,10 @@ import jakarta.inject.Inject;
 import jakarta.validation.constraints.NotNull;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import org.jspecify.annotations.Nullable;
+
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
@@ -50,7 +53,7 @@ public class RoutingMiddleware implements WebMiddleware {
 
     /** {@inheritDoc} Recognizes the route, resolves the controller and action, and delegates to the next middleware. */
     @Override
-    public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> next) {
+    public <NNREQ, NNRES> @Nullable HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, HttpResponse, NNREQ, NNRES> next) {
         request = MixinUtils.mixin(request, Routable.class);
         Class<?> controllerClass = null;
 
@@ -83,7 +86,7 @@ public class RoutingMiddleware implements WebMiddleware {
                 return response;
             }
 
-            Parameters params = request.getParams();
+            Parameters params = Objects.requireNonNull(request.getParams(), "request params");
             routing.keySet()
                     .stream()
                     .filter(k -> !k.equals("controller") && !k.equals("action"))

--- a/kotowari/src/main/java/kotowari/middleware/SerDesMiddleware.java
+++ b/kotowari/src/main/java/kotowari/middleware/SerDesMiddleware.java
@@ -22,6 +22,8 @@ import kotowari.data.BodyDeserializable;
 import kotowari.inject.ParameterInjector;
 import kotowari.util.ParameterUtils;
 
+import org.jspecify.annotations.Nullable;
+
 import jakarta.annotation.PostConstruct;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MediaType;
@@ -51,7 +53,7 @@ public class SerDesMiddleware<NRES> implements Middleware<HttpRequest, HttpRespo
 
     private final List<MessageBodyReader<?>> bodyReaders = new ArrayList<>();
     private final List<MessageBodyWriter<?>> bodyWriters = new ArrayList<>();
-    private List<ParameterInjector<?>> parameterInjectors;
+    private List<ParameterInjector<?>> parameterInjectors = ParameterUtils.getDefaultParameterInjectors();
 
     @PostConstruct
     private void loadReaderAndWriter() {
@@ -69,13 +71,10 @@ public class SerDesMiddleware<NRES> implements Middleware<HttpRequest, HttpRespo
             bodyWriters.add(writer);
         }
 
-        if (parameterInjectors == null) {
-            parameterInjectors = ParameterUtils.getDefaultParameterInjectors();
-        }
     }
 
     @SuppressWarnings("unchecked")
-    protected <T> T deserialize(HttpRequest request, Class<T> type, Type genericType, MediaType mediaType) throws IOException {
+    protected <T> @Nullable T deserialize(HttpRequest request, Class<T> type, Type genericType, MediaType mediaType) throws IOException {
         try {
             MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
             return bodyReaders.stream()
@@ -97,7 +96,7 @@ public class SerDesMiddleware<NRES> implements Middleware<HttpRequest, HttpRespo
     }
 
     @SuppressWarnings("unchecked")
-    protected InputStream serialize(Object obj, MediaType mediaType) throws IOException {
+    protected @Nullable InputStream serialize(@Nullable Object obj, MediaType mediaType) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
 
@@ -168,7 +167,7 @@ public class SerDesMiddleware<NRES> implements Middleware<HttpRequest, HttpRespo
                     if (parameterInjectors.stream().anyMatch(injector-> injector.isApplicable(type)))
                         continue;
                     bodyDeserializable.setDeserializedBody(beans.createFrom(
-                            request.getParams(), type
+                            Objects.requireNonNull(request.getParams(), "request params"), type
                     ));
                 }
             }
@@ -181,13 +180,14 @@ public class SerDesMiddleware<NRES> implements Middleware<HttpRequest, HttpRespo
     @Override
     public <NNREQ, NNRES> HttpResponse handle(HttpRequest request, MiddlewareChain<HttpRequest, NRES, NNREQ, NNRES> chain) {
         request = MixinUtils.mixin(request, BodyDeserializable.class);
-        MediaType responseType = ((ContentNegotiable) request).getMediaType();
+        MediaType responseType = Objects.requireNonNull(
+                ((ContentNegotiable) request).getMediaType(), "negotiated media type");
         try {
             handleRequest(request);
         } catch (IOException e) {
             try {
-                return builder(HttpResponse.of(serialize(Parameters.of("title",
-                        "bad request format"), responseType)))
+                return builder(HttpResponse.of(Objects.requireNonNull(serialize(Parameters.of("title",
+                        "bad request format"), responseType))))
                         .set(HttpResponse::setStatus, 400)
                         .build();
             } catch (IOException serializeEx) {
@@ -230,7 +230,7 @@ public class SerDesMiddleware<NRES> implements Middleware<HttpRequest, HttpRespo
         this.parameterInjectors = parameterInjectors;
     }
 
-    private Object extractBody(NRES response) {
+    private @Nullable Object extractBody(@Nullable NRES response) {
         if (response instanceof HasBody hasBody) {
             return hasBody.getBody();
         } else {
@@ -238,7 +238,7 @@ public class SerDesMiddleware<NRES> implements Middleware<HttpRequest, HttpRespo
         }
     }
 
-    private Headers extractHeaders(NRES response, MediaType responseType) {
+    private Headers extractHeaders(@Nullable NRES response, MediaType responseType) {
         Headers headers;
         if (response instanceof HasHeaders hasHeaders) {
             headers = hasHeaders.getHeaders();
@@ -249,7 +249,7 @@ public class SerDesMiddleware<NRES> implements Middleware<HttpRequest, HttpRespo
         return headers;
     }
 
-    private int extractStatus(NRES response) {
+    private int extractStatus(@Nullable NRES response) {
         if (response instanceof HasStatus hasStatus) {
             return hasStatus.getStatus();
         } else {

--- a/kotowari/src/main/java/kotowari/middleware/TransactionMiddleware.java
+++ b/kotowari/src/main/java/kotowari/middleware/TransactionMiddleware.java
@@ -7,6 +7,8 @@ import enkan.data.Routable;
 import enkan.exception.MisconfigurationException;
 import enkan.exception.UnreachableException;
 
+import org.jspecify.annotations.Nullable;
+
 import jakarta.inject.Inject;
 import jakarta.transaction.*;
 import java.lang.reflect.Method;
@@ -18,13 +20,13 @@ public class TransactionMiddleware<REQ, RES> implements DecoratorMiddleware<REQ,
     @Inject
     private TransactionComponent transactionComponent;
 
-    private Transactional.TxType getTransactionType(Method m) {
+    private Transactional.@Nullable TxType getTransactionType(Method m) {
         Transactional transactional = m.getDeclaredAnnotation(Transactional.class);
         return transactional != null ? transactional.value() : null;
     }
 
     @Override
-    public <NNREQ, NNRES> RES handle(REQ req, MiddlewareChain<REQ, RES, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable RES handle(REQ req, MiddlewareChain<REQ, RES, NNREQ, NNRES> chain) {
         RES res;
         if (req instanceof Routable routable) {
             Method m = routable.getControllerMethod();

--- a/kotowari/src/main/java/kotowari/middleware/ValidateBodyMiddleware.java
+++ b/kotowari/src/main/java/kotowari/middleware/ValidateBodyMiddleware.java
@@ -10,6 +10,8 @@ import enkan.util.ThreadingUtils;
 import kotowari.data.BodyDeserializable;
 import kotowari.data.Validatable;
 
+import org.jspecify.annotations.Nullable;
+
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
@@ -22,17 +24,20 @@ import java.util.Set;
  */
 @enkan.annotation.Middleware(name = "validateBody")
 public class ValidateBodyMiddleware<RES> implements Middleware<HttpRequest, RES, HttpRequest, RES> {
-    private volatile Validator validator;
+    private volatile @Nullable Validator validator;
 
     private Validator getValidator() {
-        if (validator == null) {
+        Validator v = validator;
+        if (v == null) {
             synchronized (this) {
-                if (validator == null) {
+                v = validator;
+                if (v == null) {
                     try {
                         ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
                         Runtime.getRuntime().addShutdownHook(new Thread(factory::close,
                                 "ValidateBodyMiddleware-ValidatorFactory-shutdown"));
-                        validator = factory.getValidator();
+                        v = factory.getValidator();
+                        validator = v;
                     } catch (Exception | NoClassDefFoundError e) {
                         throw new MisconfigurationException("core.MISSING_IMPLEMENTATION",
                                 "ValidateBodyMiddleware requires a Jakarta Validation provider "
@@ -41,10 +46,10 @@ public class ValidateBodyMiddleware<RES> implements Middleware<HttpRequest, RES,
                 }
             }
         }
-        return validator;
+        return v;
     }
 
-    protected Validatable getValidatable(HttpRequest request) {
+    protected @Nullable Validatable getValidatable(HttpRequest request) {
         if (request instanceof BodyDeserializable bd) {
             Object body = bd.getDeserializedBody();
             if (body instanceof Validatable v) {
@@ -55,7 +60,7 @@ public class ValidateBodyMiddleware<RES> implements Middleware<HttpRequest, RES,
     }
 
     @Override
-    public <NNREQ, NNRES> RES handle(HttpRequest request, MiddlewareChain<HttpRequest, RES, NNREQ, NNRES> chain) {
+    public <NNREQ, NNRES> @Nullable RES handle(HttpRequest request, MiddlewareChain<HttpRequest, RES, NNREQ, NNRES> chain) {
 
         Optional<Validatable> validatable = ThreadingUtils.some(getValidatable(request), form -> {
             Multimap<String, Object> errors = Multimap.empty();

--- a/kotowari/src/main/java/kotowari/middleware/package-info.java
+++ b/kotowari/src/main/java/kotowari/middleware/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package kotowari.middleware;
+
+import org.jspecify.annotations.NullMarked;

--- a/kotowari/src/main/java/kotowari/middleware/serdes/package-info.java
+++ b/kotowari/src/main/java/kotowari/middleware/serdes/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package kotowari.middleware.serdes;
+
+import org.jspecify.annotations.NullMarked;

--- a/kotowari/src/main/java/kotowari/routing/Route.java
+++ b/kotowari/src/main/java/kotowari/routing/Route.java
@@ -7,6 +7,8 @@ import enkan.web.util.CodecUtils;
 import enkan.web.util.HttpRequestUtils;
 import kotowari.routing.segment.DividerSegment;
 
+import org.jspecify.annotations.Nullable;
+
 import jakarta.ws.rs.core.MediaType;
 import java.util.*;
 import java.util.regex.Matcher;
@@ -26,12 +28,12 @@ public class Route {
 
     private final OptionMap constraints;
     private final OptionMap conditions;
-    private List<String> significantKeys;
-    private OptionMap parameterShell;
+    private @Nullable List<String> significantKeys;
+    private @Nullable OptionMap parameterShell;
     private boolean matchingPrepared;
-    private String controllerRequirement;
-    private String actionRequirement;
-    private Pattern recognizePattern;
+    private @Nullable String controllerRequirement;
+    private @Nullable String actionRequirement;
+    private @Nullable Pattern recognizePattern;
 
     /**
      * Constructs an instance of a routing given its path segments, constraints and conditions.
@@ -102,11 +104,11 @@ public class Route {
      * @return recognized routing information
      */
     @SuppressWarnings("unchecked")
-    public OptionMap recognize(HttpRequest request) {
+    public @Nullable OptionMap recognize(HttpRequest request) {
         Set<MediaType> produces = (Set<MediaType>) conditions.get("produces");
         if (produces != null && request instanceof ContentNegotiable cn) {
             MediaType produceType = cn.getMediaType();
-            if (produces.stream().noneMatch(produceType::isCompatible)) {
+            if (produceType == null || produces.stream().noneMatch(produceType::isCompatible)) {
                 return null;
             }
         }
@@ -121,10 +123,13 @@ public class Route {
             }
         }
 
-        return recognize(request.getUri(), request.getRequestMethod().toUpperCase(Locale.ENGLISH));
+        // In routing context the adapter has already populated URI and method.
+        String uri = Objects.requireNonNull(request.getUri(), "request URI");
+        String method = Objects.requireNonNull(request.getRequestMethod(), "request method");
+        return recognize(uri, method.toUpperCase(Locale.ENGLISH));
     }
 
-    public OptionMap recognize(String path, String method) {
+    public @Nullable OptionMap recognize(String path, String method) {
         List<Object> methods = conditions.getList("method");
         if (!methods.isEmpty() && !methods.contains(method)) {
             return null;
@@ -213,7 +218,7 @@ public class Route {
                 (actionRequirement == null || action.equals(actionRequirement));
     }
 
-    public String generate(OptionMap options, OptionMap hash) {
+    public @Nullable String generate(OptionMap options, OptionMap hash) {
         if (generationRequirements(options, hash)) {
             int lastIndex = segments.size() - 1;
             Segment last = segments.get(lastIndex);
@@ -231,18 +236,19 @@ public class Route {
         for(String key : constraints.keySet()) {
             Object req = constraints.get(key);
             if (req instanceof Pattern p) {
-                matched &= (hash.containsKey(key) && p.matcher(options.getString(key)).matches());
+                String optionValue = options.getString(key);
+                matched &= (hash.containsKey(key) && optionValue != null && p.matcher(optionValue).matches());
             } else {
-                matched &= hash.getString(key).equals(constraints.getString(key));
+                matched &= Objects.equals(hash.getString(key), constraints.getString(key));
             }
         }
         return matched;
     }
-    private String requirementFor(String key) {
+    private @Nullable String requirementFor(String key) {
         if (constraints.containsKey(key))
             return constraints.getString(key);
         for (Segment segment : segments) {
-            if (segment.hasKey() && segment.getKey().equals(key)) {
+            if (segment.hasKey() && key.equals(segment.getKey())) {
                 return segment.getRegexp();
             }
         }
@@ -256,7 +262,7 @@ public class Route {
         }
     }
 
-    private String appendQueryString(String path, OptionMap hash, List<String> queryKeys) {
+    private @Nullable String appendQueryString(@Nullable String path, OptionMap hash, @Nullable List<String> queryKeys) {
         if (path == null)
             return null;
 
@@ -266,17 +272,18 @@ public class Route {
         return path + buildQueryString(hash, queryKeys);
     }
 
-    private List<String> extraKeys(OptionMap hash) {
+    private List<String> extraKeys(@Nullable OptionMap hash) {
         List<String> extraKeys = new ArrayList<>();
         if (hash != null) {
+            List<String> keys = significantKeys();
             extraKeys.addAll(hash.keySet().stream()
-                    .filter(key -> !significantKeys.contains(key))
+                    .filter(key -> !keys.contains(key))
                     .toList());
         }
         return extraKeys;
     }
 
-    public String getActionRequirement() {
+    public @Nullable String getActionRequirement() {
         return actionRequirement;
     }
 

--- a/kotowari/src/main/java/kotowari/routing/RouteBuilder.java
+++ b/kotowari/src/main/java/kotowari/routing/RouteBuilder.java
@@ -3,6 +3,8 @@ package kotowari.routing;
 import enkan.collection.OptionMap;
 import kotowari.routing.segment.*;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -58,6 +60,9 @@ public class RouteBuilder {
         } else if ((m = separatorRegexp.matcher(str)).find()) {
             segment = new DividerSegment(m.group(), OptionMap.of("optional", optionalSeparators.contains(m.group())));
         }
+        if (m == null || segment == null) {
+            throw new IllegalArgumentException("Cannot parse route path segment: " + sb);
+        }
         sb.delete(0, m.end());
         return segment;
     }
@@ -67,7 +72,7 @@ public class RouteBuilder {
         options.remove("namePrefix");
 
         if (options.containsKey("namespace")) {
-            String namespace = options.getString("namespace").replace("/$", "");
+            String namespace = Objects.requireNonNull(options.getString("namespace")).replace("/$", "");
             options.remove("namespace");
             options.put("controller", namespace.replace('/', '.') + "." + options.get("controller"));
         }
@@ -95,7 +100,7 @@ public class RouteBuilder {
         return new OptionMap[]{ defaults, requirements, conditions };
     }
 
-    private Segment findSegment(List<Segment> segments, String key) {
+    private @Nullable Segment findSegment(List<Segment> segments, String key) {
         for (Segment seg : segments) {
             if (seg.hasKey() && key.equals(seg.getKey())) {
                 return seg;

--- a/kotowari/src/main/java/kotowari/routing/Routes.java
+++ b/kotowari/src/main/java/kotowari/routing/Routes.java
@@ -7,6 +7,8 @@ import kotowari.routing.factory.RoutePatterns;
 import kotowari.routing.factory.RoutePatternsDescriptor;
 import kotowari.routing.recognizer.OptimizedRecognizer;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -39,7 +41,7 @@ public class Routes {
     public static RoutePatterns define(RoutePatternsDescriptor descriptor) {
         return define(null, descriptor);
     }
-    public static RoutePatterns define(String prefix, RoutePatternsDescriptor descriptor) {
+    public static RoutePatterns define(@Nullable String prefix, RoutePatternsDescriptor descriptor) {
         RoutePatterns patterns = new RoutePatterns(prefix, routeList -> {
             Routes routes = new Routes(routeList);
             routes.recognizer.setRoutes(routeList);

--- a/kotowari/src/main/java/kotowari/routing/Segment.java
+++ b/kotowari/src/main/java/kotowari/routing/Segment.java
@@ -3,7 +3,10 @@ package kotowari.routing;
 import enkan.collection.OptionMap;
 import enkan.web.util.CodecUtils;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -13,13 +16,13 @@ import java.util.regex.Pattern;
 public abstract class Segment {
     public static final String RESERVED_PCHAR = ":@&=+$,;";
 
-    private String value;
+    private @Nullable String value;
     private boolean isOptional;
 
     public Segment() {
         this(null);
     }
-    public Segment(String value) {
+    public Segment(@Nullable String value) {
         this.value = value;
         isOptional = false;
     }
@@ -28,7 +31,7 @@ public abstract class Segment {
         return Pattern.compile(regexpChunk()).matcher("").groupCount();
     }
 
-    public String getExtractionCode() {
+    public @Nullable String getExtractionCode() {
         return null;
     }
 
@@ -41,7 +44,8 @@ public abstract class Segment {
         }
     }
     public String interpolationChunk(OptionMap hash) {
-        return CodecUtils.urlEncode(value);
+        // Only reached for segments that carry a value (e.g. StaticSegment).
+        return CodecUtils.urlEncode(Objects.requireNonNull(value));
     }
 
     public String interpolationStatement(List<Segment> list, OptionMap hash) {
@@ -59,8 +63,12 @@ public abstract class Segment {
 
     public boolean allOptionalsAvailableCondition(List<Segment> priorSegments, OptionMap hash) {
         for (Segment segment : priorSegments) {
-            if (!segment.isOptional() && segment.hasKey() && hash.getString(segment.getKey()).isEmpty()) {
-                return false;
+            String key = segment.getKey();
+            if (!segment.isOptional() && key != null) {
+                String v = hash.getString(key);
+                if (v == null || v.isEmpty()) {
+                    return false;
+                }
             }
         }
         return true;
@@ -73,7 +81,7 @@ public abstract class Segment {
         return false;
     }
 
-    public String getKey() {
+    public @Nullable String getKey() {
         return null;
     }
 
@@ -81,11 +89,11 @@ public abstract class Segment {
         return false;
     }
 
-    public String getDefault() {
+    public @Nullable String getDefault() {
         return null;
     }
 
-    public String getValue() {
+    public @Nullable String getValue() {
         return value;
     }
 
@@ -99,13 +107,11 @@ public abstract class Segment {
     }
 
     public void setRegexp(Pattern regexp) {}
-    public void setDefault(String def) {}
+    public void setDefault(@Nullable String def) {}
 
-    public String buildPattern(String pattern) {
-        return null;
-    }
+    public abstract String buildPattern(String pattern);
 
-    public String getRegexp() {
+    public @Nullable String getRegexp() {
         return null;
     }
 }

--- a/kotowari/src/main/java/kotowari/routing/factory/RoutePatterns.java
+++ b/kotowari/src/main/java/kotowari/routing/factory/RoutePatterns.java
@@ -5,6 +5,8 @@ import kotowari.routing.Route;
 import kotowari.routing.RouteBuilder;
 import kotowari.routing.Routes;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
@@ -20,7 +22,7 @@ public class RoutePatterns {
     private final RouteBuilder builder;
     private final Function<List<Route>, Routes> routeCompiler;
 
-    public RoutePatterns(String prefix, Function<List<Route>, Routes> routeCompiler) {
+    public RoutePatterns(@Nullable String prefix, Function<List<Route>, Routes> routeCompiler) {
         this.routeCompiler = routeCompiler;
 
         routeList = new ArrayList<>();
@@ -28,7 +30,7 @@ public class RoutePatterns {
         context = new PatternsContext(prefix, this);
     }
 
-    RoutingCondition httpMethodCondition(String method, String path) {
+    RoutingCondition httpMethodCondition(@Nullable String method, String path) {
         RoutingCondition cond = new RoutingCondition(method, path);
         cond.setContext(context);
         return cond;
@@ -58,7 +60,7 @@ public class RoutePatterns {
         return httpMethodCondition("DELETE", path);
     }
 
-    public Route resource(Class<?> controller) {
+    public @Nullable Route resource(Class<?> controller) {
         return resource(controller, null);
     }
 
@@ -70,7 +72,7 @@ public class RoutePatterns {
         }
     }
 
-    public Route resource(Class<?> controller, OptionMap options) {
+    public @Nullable Route resource(Class<?> controller, @Nullable OptionMap options) {
         String name = decapitalize(controller.getSimpleName().replaceAll("Controller$", ""));
         get(name + "/").to(controller, "index");
         get(name + "/:id"     ).requires("id", "\\d+").to(controller, "show");
@@ -101,7 +103,7 @@ public class RoutePatterns {
         return routeCompiler.apply(routeList);
     }
 
-    public record PatternsContext(String prefix, RoutePatterns patterns) {
+    public record PatternsContext(@Nullable String prefix, RoutePatterns patterns) {
         public void addRoute(Route route) {
             patterns.addRoute_(route);
         }

--- a/kotowari/src/main/java/kotowari/routing/factory/RoutingCondition.java
+++ b/kotowari/src/main/java/kotowari/routing/factory/RoutingCondition.java
@@ -3,6 +3,8 @@ package kotowari.routing.factory;
 import enkan.collection.OptionMap;
 import kotowari.routing.Route;
 
+import org.jspecify.annotations.Nullable;
+
 import jakarta.ws.rs.core.MediaType;
 import java.util.Arrays;
 import java.util.Collections;
@@ -17,14 +19,14 @@ import java.util.stream.Collectors;
  * @author kawasima
  */
 public class RoutingCondition {
-    private final String method;
+    private final @Nullable String method;
     private final String path;
     private final OptionMap requirements;
     private Set<MediaType> consumes;
     private Set<MediaType> produces;
-    private RoutePatterns.PatternsContext context;
+    private RoutePatterns.@Nullable PatternsContext context;
 
-    public RoutingCondition(String method, String path) {
+    public RoutingCondition(@Nullable String method, String path) {
         this.method = method;
         this.path = path;
         this.requirements = OptionMap.empty();
@@ -85,7 +87,7 @@ public class RoutingCondition {
      * @param controllerMethod The method of destination
      * @return a routing definition
      */
-    public Route to(Class<?> controllerClass, String controllerMethod) {
+    public Route to(Class<?> controllerClass, @Nullable String controllerMethod) {
         OptionMap conditions = OptionMap.empty();
         if (method != null) {
             conditions.put("method", method);
@@ -106,8 +108,9 @@ public class RoutingCondition {
             options.put("requirements", requirements);
         }
 
-        Route route = context.build(path, options);
-        context.addRoute(route);
+        RoutePatterns.PatternsContext ctx = Objects.requireNonNull(context, "routing context");
+        Route route = ctx.build(path, options);
+        ctx.addRoute(route);
         return route;
     }
 }

--- a/kotowari/src/main/java/kotowari/routing/factory/package-info.java
+++ b/kotowari/src/main/java/kotowari/routing/factory/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package kotowari.routing.factory;
+
+import org.jspecify.annotations.NullMarked;

--- a/kotowari/src/main/java/kotowari/routing/package-info.java
+++ b/kotowari/src/main/java/kotowari/routing/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package kotowari.routing;
+
+import org.jspecify.annotations.NullMarked;

--- a/kotowari/src/main/java/kotowari/routing/recognizer/OptimizedRecognizer.java
+++ b/kotowari/src/main/java/kotowari/routing/recognizer/OptimizedRecognizer.java
@@ -4,6 +4,8 @@ import enkan.collection.OptionMap;
 import enkan.web.data.HttpRequest;
 import kotowari.routing.*;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -13,8 +15,8 @@ import java.util.stream.Collectors;
  * @author kawasima
  */
 public class OptimizedRecognizer implements Recognizer {
-    private SegmentNode tree;
-    private List<Route> routes;
+    private @Nullable SegmentNode tree;
+    private List<Route> routes = new ArrayList<>();
 
     public String[] toPlainSegments(String str) {
         str = str.replaceAll("^/+", "").replaceAll("/+$", "");
@@ -66,9 +68,9 @@ public class OptimizedRecognizer implements Recognizer {
 
     @Override
     public OptionMap recognize(HttpRequest request) {
-        String[] segments = toPlainSegments(request.getUri());
+        String[] segments = toPlainSegments(Objects.requireNonNull(request.getUri(), "request URI"));
 
-        int index = calcIndex(segments, tree, 0);
+        int index = calcIndex(segments, Objects.requireNonNull(tree, "recognizer not optimized"), 0);
         while (index < routes.size()) {
             OptionMap result = routes.get(index).recognize(request);
             if (result != null) return result;
@@ -79,14 +81,14 @@ public class OptimizedRecognizer implements Recognizer {
 
     private static class SegmentNode {
         private final int index;
-        private final String label;
+        private final @Nullable String label;
         private final List<SegmentNode> childNodes;
 
         SegmentNode(int index) {
             this(null, index);
         }
 
-        SegmentNode(String label, int index) {
+        SegmentNode(@Nullable String label, int index) {
             this.index = index;
             this.label = label;
             childNodes = new ArrayList<>();
@@ -100,13 +102,13 @@ public class OptimizedRecognizer implements Recognizer {
             return childNodes.isEmpty();
         }
 
-        SegmentNode lastChild() {
+        @Nullable SegmentNode lastChild() {
             if (isEmpty())
                 return null;
             return childNodes.getLast();
         }
 
-        String getLabel() {
+        @Nullable String getLabel() {
             return label;
         }
 

--- a/kotowari/src/main/java/kotowari/routing/recognizer/package-info.java
+++ b/kotowari/src/main/java/kotowari/routing/recognizer/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package kotowari.routing.recognizer;
+
+import org.jspecify.annotations.NullMarked;

--- a/kotowari/src/main/java/kotowari/routing/segment/DividerSegment.java
+++ b/kotowari/src/main/java/kotowari/routing/segment/DividerSegment.java
@@ -2,11 +2,13 @@ package kotowari.routing.segment;
 
 import enkan.collection.OptionMap;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * @author kawasima
  */
 public class DividerSegment extends StaticSegment {
-    public DividerSegment(String value, OptionMap options) {
+    public DividerSegment(@Nullable String value, OptionMap options) {
         super(value, setDefault(options));
     }
 

--- a/kotowari/src/main/java/kotowari/routing/segment/DynamicSegment.java
+++ b/kotowari/src/main/java/kotowari/routing/segment/DynamicSegment.java
@@ -6,7 +6,10 @@ import kotowari.routing.RegexpUtils;
 import kotowari.routing.RouteBuilder;
 import kotowari.routing.Segment;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -15,8 +18,8 @@ import java.util.regex.Pattern;
  */
 public class DynamicSegment extends Segment {
     private final String key;
-    private String defaultValue;
-    private Pattern regexp;
+    private @Nullable String defaultValue;
+    private @Nullable Pattern regexp;
     private boolean wrapParentheses = false;
 
     public DynamicSegment(String key) {
@@ -27,7 +30,7 @@ public class DynamicSegment extends Segment {
         if (options.containsKey("default"))
             this.defaultValue = options.getString("default");
         if (options.containsKey("regexp"))
-            this.regexp = Pattern.compile(options.getString("regexp"));
+            this.regexp = Pattern.compile(Objects.requireNonNull(options.getString("regexp")));
         if (options.containsKey("wrapParentheses"))
             this.wrapParentheses = options.getBoolean("wrapParentheses");
     }
@@ -61,12 +64,12 @@ public class DynamicSegment extends Segment {
         return true;
     }
     @Override
-    public String getDefault() {
+    public @Nullable String getDefault() {
         return defaultValue;
     }
 
     @Override
-    public void setDefault(String defaultValue) {
+    public void setDefault(@Nullable String defaultValue) {
         this.defaultValue = defaultValue;
     }
 
@@ -100,6 +103,9 @@ public class DynamicSegment extends Segment {
     @Override
     public String interpolationChunk(OptionMap hash) {
         String value = hash.getString(getKey());
+        if (value == null) {
+            return "";
+        }
         try {
             return CodecUtils.urlEncode(value);
         } catch(Exception e) {
@@ -110,7 +116,7 @@ public class DynamicSegment extends Segment {
     @Override
     public String stringStructure(List<Segment> list, OptionMap hash) {
         if (isOptional()) {
-            if (hash.getString(getKey()).equals(getDefault())) {
+            if (Objects.equals(hash.getString(getKey()), getDefault())) {
                 return continueStringStructure(list, hash);
             } else {
                 return interpolationStatement(list, hash);

--- a/kotowari/src/main/java/kotowari/routing/segment/OptionalFormatSegment.java
+++ b/kotowari/src/main/java/kotowari/routing/segment/OptionalFormatSegment.java
@@ -3,13 +3,15 @@ package kotowari.routing.segment;
 import enkan.collection.OptionMap;
 import enkan.web.util.CodecUtils;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.regex.Matcher;
 
 /**
  * @author kawasima
  */
 public class OptionalFormatSegment extends DynamicSegment{
-    public OptionalFormatSegment(String key, OptionMap options) {
+    public OptionalFormatSegment(@Nullable String key, OptionMap options) {
         super("format", OptionMap.of("optional", true));
     }
 
@@ -38,7 +40,8 @@ public class OptionalFormatSegment extends DynamicSegment{
         if (m != null) {
             params.put(getKey(), CodecUtils.urlDecode(m.substring(1)));
         } else {
-            params.put(getKey(), CodecUtils.urlDecode(getDefault()));
+            String def = getDefault();
+            params.put(getKey(), def == null ? null : CodecUtils.urlDecode(def));
         }
     }
 }

--- a/kotowari/src/main/java/kotowari/routing/segment/PathSegment.java
+++ b/kotowari/src/main/java/kotowari/routing/segment/PathSegment.java
@@ -4,6 +4,8 @@ import enkan.collection.OptionMap;
 import enkan.exception.UnreachableException;
 import enkan.web.util.CodecUtils;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -19,6 +21,9 @@ public class PathSegment extends DynamicSegment {
     @Override
     public String interpolationChunk(OptionMap hash) {
         String value = hash.getString(getKey());
+        if (value == null) {
+            return "";
+        }
         try {
             value = CodecUtils.urlEncode(value);
             Matcher m = ENCODED_SLASH.matcher(value);
@@ -33,8 +38,8 @@ public class PathSegment extends DynamicSegment {
         return "";
     }
 
-    public void setDefault(String path) {
-        if (!path.isEmpty())
+    public void setDefault(@Nullable String path) {
+        if (path != null && !path.isEmpty())
             throw new UnreachableException();
     }
 

--- a/kotowari/src/main/java/kotowari/routing/segment/StaticSegment.java
+++ b/kotowari/src/main/java/kotowari/routing/segment/StaticSegment.java
@@ -4,6 +4,10 @@ import enkan.collection.OptionMap;
 import kotowari.routing.RegexpUtils;
 import kotowari.routing.Segment;
 
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
+
 /**
  * @author kawasima
  */
@@ -11,11 +15,11 @@ public class StaticSegment extends Segment {
 
     private boolean raw;
 
-    public StaticSegment(String value) {
+    public StaticSegment(@Nullable String value) {
         this(value, OptionMap.of());
     }
 
-    public StaticSegment(String value,  OptionMap options) {
+    public StaticSegment(@Nullable String value,  OptionMap options) {
         super(value);
         if (options.containsKey("raw")) {
             this.raw = options.getBoolean("raw");
@@ -28,12 +32,12 @@ public class StaticSegment extends Segment {
 
     @Override
     public String interpolationChunk(OptionMap hash) {
-        return raw ? getValue() : super.interpolationChunk(hash);
+        return raw ? Objects.requireNonNull(getValue()) : super.interpolationChunk(hash);
     }
 
     @Override
     public String regexpChunk() {
-        String chunk = RegexpUtils.escape(getValue());
+        String chunk = RegexpUtils.escape(Objects.requireNonNull(getValue()));
         return isOptional() ? RegexpUtils.optionalize(chunk) : chunk;
     }
 
@@ -44,7 +48,7 @@ public class StaticSegment extends Segment {
 
     @Override
     public String buildPattern(String pattern) {
-        String escaped = RegexpUtils.escape(getValue());
+        String escaped = RegexpUtils.escape(Objects.requireNonNull(getValue()));
         if (isOptional() && !pattern.isEmpty()) {
             return "(?:" + RegexpUtils.optionalize(escaped) + "\\Z|" + escaped + RegexpUtils.unoptionalize(pattern) + ")";
         } else if (isOptional()) {
@@ -56,6 +60,6 @@ public class StaticSegment extends Segment {
 
     @Override
     public String toString() {
-        return getValue();
+        return Objects.requireNonNullElse(getValue(), "");
     }
 }

--- a/kotowari/src/main/java/kotowari/routing/segment/package-info.java
+++ b/kotowari/src/main/java/kotowari/routing/segment/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package kotowari.routing.segment;
+
+import org.jspecify.annotations.NullMarked;

--- a/kotowari/src/main/java/kotowari/scope/ExportSetting.java
+++ b/kotowari/src/main/java/kotowari/scope/ExportSetting.java
@@ -1,5 +1,7 @@
 package kotowari.scope;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,7 +28,7 @@ public record ExportSetting(Map<ExportableScope, String> exports) {
         return new ExportSetting(Map.copyOf(map));
     }
 
-    public String getExportName(ExportableScope scope) {
+    public @Nullable String getExportName(ExportableScope scope) {
         return exports.get(scope);
     }
 

--- a/kotowari/src/main/java/kotowari/scope/package-info.java
+++ b/kotowari/src/main/java/kotowari/scope/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package kotowari.scope;
+
+import org.jspecify.annotations.NullMarked;

--- a/kotowari/src/main/java/kotowari/system/package-info.java
+++ b/kotowari/src/main/java/kotowari/system/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package kotowari.system;
+
+import org.jspecify.annotations.NullMarked;

--- a/kotowari/src/main/java/kotowari/util/package-info.java
+++ b/kotowari/src/main/java/kotowari/util/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package kotowari.util;
+
+import org.jspecify.annotations.NullMarked;

--- a/kotowari/src/main/java/module-info.java
+++ b/kotowari/src/main/java/module-info.java
@@ -10,6 +10,7 @@ module kotowari {
     exports kotowari.util;
 
     requires transitive enkan.web;
+    requires transitive org.jspecify;
     requires jakarta.annotation;
     requires jakarta.cdi;
     requires jakarta.transaction;

--- a/kotowari/src/test/java/kotowari/middleware/FormMiddlewareTest.java
+++ b/kotowari/src/test/java/kotowari/middleware/FormMiddlewareTest.java
@@ -94,8 +94,8 @@ public class FormMiddlewareTest {
         request = MixinUtils.mixin(request, Routable.class);
         Method method = tryReflection(() -> TestController.class.getMethod("index", NestedForm.class));
         ((Routable) request).setControllerMethod(method);
-        formMiddleware.handle(request, new DefaultMiddlewareChain<>(Predicates.none(), "dummy",
-                (Endpoint<HttpRequest, HttpResponse>) r -> null));
+        formMiddleware.handle(request, new DefaultMiddlewareChain<>(Predicates.any(), "dummy",
+                (Endpoint<HttpRequest, HttpResponse>) r -> HttpResponse.of("")));
 
         NestedForm form = ((BodyDeserializable) request).getDeserializedBody();
         assertThat(form.getIntVal()).isEqualTo(123);

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <jakarta.persistence.version>3.2.0</jakarta.persistence.version>
 
         <doma.version>2.62.1</doma.version>
+        <jspecify.version>1.0.0</jspecify.version>
         <slf4j.version>2.0.17</slf4j.version>
         <junit.version>5.14.3</junit.version>
         <assertj.version>3.27.7</assertj.version>
@@ -237,6 +238,11 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.jspecify</groupId>
+                <artifactId>jspecify</artifactId>
+                <version>${jspecify.version}</version>
+            </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>enkan-core</artifactId>


### PR DESCRIPTION
## Summary

Adopt [JSpecify](https://jspecify.dev/) nullability annotations across **every published module** of Enkan (Spring Framework's approach, "level A"): mark packages `@NullMarked` and annotate the genuinely-nullable points of the public API with `@Nullable`, so downstream applications running NullAway / IntelliJ get null-safety against the framework.

NullAway is used **only transiently** to discover and validate `@Nullable` placement and is **not** wired into the committed build — no permanent Error Prone / NullAway in CI (that would be a separate, opt-in "level B" decision).

The whole reactor is **NullAway-clean (0 violations)** and `mvn clean test -DexcludedGroups=integration` passes (**30/30 modules**, verified in an IDE-race-free environment under JDK 25).

## Scope

All published modules: `enkan-core`, `enkan-web`, `enkan-system`, `kotowari`, `kotowari-jpa`, `kotowari-graalvm`, `enkan-servlet`, `enkan-throttling`, `enkan-repl` / `enkan-repl-server` / `enkan-repl-client`, `enkan-devel` / `enkan-devel-gradle`, and all `enkan-component-*` (HikariCP, jackson, micrometer, metrics, opentelemetry, flyway, freemarker, thymeleaf, jetty, jooq, undertow, doma2, jpa, eclipselink).

Out of scope: `kotowari-example`, `kotowari-graalvm-example`.

## Mechanics

- `org.jspecify:jspecify` (1.0.0) managed in the parent POM, declared as a compile dependency per module.
- One `@NullMarked` `package-info.java` per package.
- JPMS modules get `requires transitive org.jspecify` (`static` alone breaks downstream compilation because the annotations appear in exported public signatures).

## Notable API changes (breaking)

Rather than sprinkling `@Nullable` to satisfy the checker, null-returns that were a design smell were fixed by design; where null is genuinely part of the contract it is annotated honestly.

- **`HttpRequest` / `HttpResponse`**: every setter-populated accessor is `@Nullable`. These are mutable beans populated incrementally, and a `null` field is meaningful ("not yet populated" — `ParamsMiddleware` / `CookiesMiddleware` key off `getParams() == null`). This is enforced by existing tests (`DefaultHttpRequestTest.defaultStateHasNullFields`).
- **`Middleware.handle`, `Endpoint.handle`, `Application.handle`, `MiddlewareChain.next`** return `@Nullable RES` — a middleware/endpoint may legitimately yield `null` (pass-through when downstream returned null; a resource endpoint serving a missing file). This is distinct from an **exhausted chain**, which now throws `MisconfigurationException("core.MIDDLEWARE_CHAIN_EXHAUSTED")` via a terminal sentinel instead of silently returning `null`.
- **`enkan.data` capability interfaces** made `@Nullable` where the value is genuinely optional: `Extendable.getExtension`/`setExtension`, `SessionAvailable.getSession`, `PrincipalAvailable.getPrincipal`, `FlashAvailable.getFlash`, `ConversationAvailable`, `UriAvailable`.
- Design-over-`@Nullable` examples: `MixinUtils.mixin`/`getAllInterfaces` require non-null in/out (the null-passthrough branches were dead); `Segment.buildPattern` made `abstract`; `RouteBuilder.segmentFor` throws instead of returning an unreachable `null`; `MisconfigurationException.getCode()` keeps a non-null `code` field.
- Component lifecycle getters (datasource, meter/tracer registries, factories, …) are `@Nullable` — they are null before `start()` / after `stop()`, matching existing tests.

Also fixes one latent nullability inconsistency surfaced by the cross-module re-scan: `DefaultHttpResponse.setExtension` was narrowing the `@Nullable` override contract.

## Verification

- NullAway 0 across the reactor (discovered/validated with a throwaway Error Prone 2.38.0 + NullAway 0.12.9 profile on JDK 25, removed before commit).
- `mvn -B clean test -DexcludedGroups=integration` → BUILD SUCCESS, 30/30 modules, zero failures.

## Notes for reviewers

- Requires JDK 25 to build (`--release 25 --enable-preview`; `enkan-web` uses `StructuredTaskScope`).
- One commit per module for readability.
- No test assertions were changed; a couple of tests that relied on the old null-return-from-exhausted-chain behavior were pointed at a proper terminal instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
